### PR TITLE
feat: add admin settings button to golem layout

### DIFF
--- a/app/admin/golem/layout.tsx
+++ b/app/admin/golem/layout.tsx
@@ -3,7 +3,7 @@
 import { useSession } from 'next-auth/react';
 import { useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
-import { Briefcase, Bell, Moon, FileText, ArrowLeft, Bot } from 'lucide-react';
+import { Briefcase, Bell, Moon, FileText, ArrowLeft, Bot, Settings } from 'lucide-react';
 import { useEffect } from 'react';
 
 const navItems = [
@@ -99,6 +99,15 @@ export default function GolemLayout({
           {children}
         </div>
       </main>
+
+      {/* Admin settings button */}
+      <Link
+        href="/admin"
+        className="fixed bottom-6 right-6 flex h-12 w-12 items-center justify-center rounded-full bg-white/10 border border-white/20 text-white/60 hover:bg-white/20 hover:text-white transition-colors shadow-lg"
+        title="Admin Settings"
+      >
+        <Settings className="h-5 w-5" />
+      </Link>
     </div>
   );
 }

--- a/app/admin/golem/layout.tsx
+++ b/app/admin/golem/layout.tsx
@@ -3,7 +3,7 @@
 import { useSession } from 'next-auth/react';
 import { useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
-import { Briefcase, Bell, Moon, FileText, ArrowLeft, Bot, Settings } from 'lucide-react';
+import { Briefcase, Bell, Moon, FileText, ArrowLeft, Bot } from 'lucide-react';
 import { useEffect } from 'react';
 
 const navItems = [
@@ -99,15 +99,6 @@ export default function GolemLayout({
           {children}
         </div>
       </main>
-
-      {/* Admin settings button */}
-      <Link
-        href="/admin"
-        className="fixed bottom-6 right-6 flex h-12 w-12 items-center justify-center rounded-full bg-white/10 border border-white/20 text-white/60 hover:bg-white/20 hover:text-white transition-colors shadow-lg"
-        title="Admin Settings"
-      >
-        <Settings className="h-5 w-5" />
-      </Link>
     </div>
   );
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -42,6 +42,13 @@ export default function AdminPage() {
                 <p className="text-sm text-white/60">Autonomous agent dashboard</p>
               </div>
             </div>
+            <Link
+              href="/admin/golem"
+              className="flex items-center justify-center gap-2 w-full p-3 rounded-lg bg-emerald-500/20 border border-emerald-500/30 hover:bg-emerald-500/30 transition-colors mb-3"
+            >
+              <Bot className="h-4 w-4 text-emerald-400" />
+              <span className="text-sm font-medium text-emerald-400">Open Dashboard</span>
+            </Link>
             <div className="grid grid-cols-2 gap-3">
               <Link
                 href="/admin/golem/jobs"

--- a/app/components/AdminFloatingMenu.tsx
+++ b/app/components/AdminFloatingMenu.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useSession, signOut } from 'next-auth/react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { Settings, LogOut, Plus, Home } from 'lucide-react';
+import { Settings, LogOut, Plus, Home, Bot } from 'lucide-react';
 
 export default function AdminFloatingMenu() {
   const { data: session } = useSession();
@@ -54,7 +54,16 @@ export default function AdminFloatingMenu() {
                 <Home className="h-4 w-4" />
                 Admin Dashboard
               </Link>
-              
+
+              <Link
+                href="/admin/golem"
+                onClick={() => setIsOpen(false)}
+                className="flex items-center gap-3 rounded px-3 py-2 text-sm text-emerald-400 transition-colors hover:bg-gray-800"
+              >
+                <Bot className="h-4 w-4" />
+                ClaudeGolem
+              </Link>
+
               <Link
                 href="/projects/add"
                 onClick={() => setIsOpen(false)}


### PR DESCRIPTION
Floating gear button at bottom-right links to /admin

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only navigation changes (adds links/icons) with no backend/auth logic modifications.
> 
> **Overview**
> Adds a new **ClaudeGolem “Open Dashboard”** CTA on `app/admin/page.tsx` that links to `/admin/golem` above the existing sub-links.
> 
> Updates `AdminFloatingMenu` to include a **ClaudeGolem** menu item (with `Bot` icon) that routes to `/admin/golem` alongside the existing Admin Dashboard/Add Project/Logout actions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c73fae207d8b808a3c46a48876396bca280086d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quick-access navigation buttons to the ClaudeGolem dashboard, now accessible from multiple locations within the admin interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->