### PR TITLE
fix: jobs pagination + live service status indicators

### DIFF
--- a/app/admin/golem/page.tsx
+++ b/app/admin/golem/page.tsx
@@ -306,37 +306,33 @@ export default function GolemOverview() {
           </div>
         </div>
 
-        {/* Bot Schedule */}
+        {/* Bot Schedule — Live Status */}
         <div className="rounded-xl border border-white/10 bg-white/5 p-5">
           <h2 className="text-sm font-semibold text-white/80 flex items-center gap-2 mb-4">
             <Clock className="h-4 w-4 text-indigo-400" />
-            Bot Schedule (Israel Time)
+            Service Status (Israel Time)
           </h2>
           <div className="space-y-3 text-xs">
+            {stats.serviceStatuses.map((svc) => (
+              <div key={svc.name} className="flex items-center gap-3">
+                <span className={`w-2 h-2 rounded-full shrink-0 ${
+                  svc.status === 'ok' ? 'bg-emerald-400' :
+                  svc.status === 'stale' ? 'bg-amber-400 animate-pulse' :
+                  'bg-white/20'
+                }`} />
+                <span className="text-white/70 flex-1">{svc.name}</span>
+                <span className="text-white/40 text-right">
+                  {svc.lastRun ? formatTimeAgo(svc.lastRun) : 'never'}
+                </span>
+                <span className="text-white/30 hidden sm:inline">{svc.schedule}</span>
+              </div>
+            ))}
+            {/* Static entry for Soltome (no state key yet) */}
             <div className="flex items-center gap-3">
-              <span className="w-2 h-2 rounded-full bg-blue-400" />
-              <span className="text-white/70 flex-1">Email Golem</span>
-              <span className="text-white/40">Hourly 6am-7pm, 10pm check</span>
-            </div>
-            <div className="flex items-center gap-3">
-              <span className="w-2 h-2 rounded-full bg-emerald-400" />
-              <span className="text-white/70 flex-1">Job Golem</span>
-              <span className="text-white/40">6am, 9am, 1pm Sun-Thu</span>
-            </div>
-            <div className="flex items-center gap-3">
-              <span className="w-2 h-2 rounded-full bg-violet-400" />
-              <span className="text-white/70 flex-1">Morning Briefing</span>
-              <span className="text-white/40">8am daily</span>
-            </div>
-            <div className="flex items-center gap-3">
-              <span className="w-2 h-2 rounded-full bg-amber-400" />
+              <span className="w-2 h-2 rounded-full bg-white/20 shrink-0" />
               <span className="text-white/70 flex-1">Soltome Learner</span>
-              <span className="text-white/40">2am daily</span>
-            </div>
-            <div className="flex items-center gap-3">
-              <span className="w-2 h-2 rounded-full bg-indigo-400" />
-              <span className="text-white/70 flex-1">Night Shift</span>
-              <span className="text-white/40">4am daily (local)</span>
+              <span className="text-white/40 text-right">—</span>
+              <span className="text-white/30 hidden sm:inline">2am daily</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- **Jobs pagination**: Replaced hard `.limit(100)` with proper offset pagination using `page`/`pageSize` params and Supabase `.range()`. Shows total count from `count: 'exact'`, prev/next controls. Resets to page 0 when filters change.
- **Service status indicators**: Bot Schedule section now reads from Supabase `golem_state` table to show live last-run times. Green dot = ran within threshold, amber pulse = stale (overdue), gray = never ran. Each service shows "Xh ago" instead of static schedule text.

## What was broken
- Jobs tab showed only 100 of 147+ jobs due to hardcoded `.limit(100)`
- Bot Schedule was static text with no visibility into whether services are actually running

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] All 17 tests pass (vitest)
- [ ] Verify jobs page shows all jobs across pages with pagination controls
- [ ] Verify overview shows green/amber/gray dots for each service
- [ ] Verify service last-run times update after Railway golems run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches admin data-fetching queries and UI state management; main risk is pagination/count correctness and potential performance impact from `count: 'exact'` and the new `golem_state` read.
> 
> **Overview**
> Fixes the admin Jobs view only showing the first 100 rows by switching `getJobs` to offset pagination (`page`/`pageSize` via Supabase `.range()`), returning an exact total count, and adding prev/next paging controls that reset to page 0 when filters/search change.
> 
> Replaces the Overview “Bot Schedule” static list with **live service status**: `getOverviewStats` now reads `golem_state` and computes per-service last-run timestamps plus `ok`/`stale`/`unknown` based on thresholds, which the UI renders as colored indicators and “time ago” text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f980ccf817a6a48af017ab0f349a837d2cd01e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service status monitoring with live health indicators (ok, stale, unknown) and last run timestamps on the dashboard
  * Pagination support for jobs list, displaying total job count with prev/next navigation controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->