### PR TITLE
fix: use service-role key for admin dashboard

### DIFF
--- a/app/admin/golem/actions/data.ts
+++ b/app/admin/golem/actions/data.ts
@@ -2,7 +2,7 @@
 
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/app/lib/auth';
-import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
 
 const RAILWAY_HEALTH_URL = process.env.RAILWAY_HEALTH_URL || 'https://golems-production.up.railway.app/health';
 
@@ -93,7 +93,7 @@ export interface OverviewStats {
 export async function getOverviewStats(): Promise<{ data: OverviewStats | null; error: string | null }> {
   try {
     await requireAuth();
-    const supabase = await createClient();
+    const supabase = createAdminClient();
 
     const [emailsRes, jobsRes, eventsCountRes, eventsRes, contactsRes, allEmailsRes, allJobsRes, stateRes] = await Promise.all([
       supabase.from('emails').select('id', { count: 'exact', head: true }),
@@ -213,7 +213,7 @@ export async function getOverviewStats(): Promise<{ data: OverviewStats | null; 
 export async function getEvents(limit = 50): Promise<{ events: GolemEvent[]; error: string | null }> {
   try {
     await requireAuth();
-    const supabase = await createClient();
+    const supabase = createAdminClient();
     const { data, error } = await supabase
       .from('golem_events')
       .select('*')
@@ -237,7 +237,7 @@ export async function getEmails(filters?: {
 }): Promise<{ emails: Email[]; error: string | null }> {
   try {
     await requireAuth();
-    const supabase = await createClient();
+    const supabase = createAdminClient();
 
     let query = supabase
       .from('emails')
@@ -268,7 +268,7 @@ export async function getEmails(filters?: {
 export async function getGolemState(): Promise<{ state: GolemState[]; error: string | null }> {
   try {
     await requireAuth();
-    const supabase = await createClient();
+    const supabase = createAdminClient();
     const { data, error } = await supabase
       .from('golem_state')
       .select('*')
@@ -290,7 +290,7 @@ export async function getOutreachData(): Promise<{
 }> {
   try {
     await requireAuth();
-    const supabase = await createClient();
+    const supabase = createAdminClient();
 
     const [contactsRes, messagesRes] = await Promise.all([
       supabase.from('outreach_contacts').select('*').order('created_at', { ascending: false }),

--- a/app/admin/golem/jobs/actions/jobs.ts
+++ b/app/admin/golem/jobs/actions/jobs.ts
@@ -2,7 +2,7 @@
 
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/app/lib/auth';
-import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
 import { escapePostgrestSearch } from './utils';
 
 // Verify session before any operation
@@ -55,7 +55,7 @@ export async function getJobs(filters?: {
   try {
     await requireAuth();
 
-    const supabase = await createClient();
+    const supabase = createAdminClient();
     const page = filters?.page ?? 0;
     const pageSize = filters?.pageSize ?? 100;
     const from = page * pageSize;
@@ -106,7 +106,7 @@ export async function updateJobStatus(
       return { success: false, error: `Invalid status: ${status}` };
     }
 
-    const supabase = await createClient();
+    const supabase = createAdminClient();
     
     const { error } = await supabase
       .from('golem_jobs')

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -1,0 +1,20 @@
+import { createClient } from '@supabase/supabase-js'
+
+/**
+ * Server-only Supabase client using the service role key.
+ * Bypasses RLS — ONLY use in auth-gated server actions (requireAuth()).
+ * The SUPABASE_SERVICE_KEY env var has no NEXT_PUBLIC_ prefix,
+ * so Next.js never exposes it to the browser.
+ */
+export function createAdminClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_KEY
+
+  if (!url || !serviceKey) {
+    throw new Error('Missing SUPABASE_SERVICE_KEY — required for admin dashboard')
+  }
+
+  return createClient(url, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
+}


### PR DESCRIPTION
## Summary
- Dashboard showed no data because golem tables have RLS enabled and the anon key returns 0 rows
- Created `lib/supabase/admin.ts` with a service-role client for server-side admin routes
- Updated all admin golem actions to use `createAdminClient()` instead of `createClient()`
- `SUPABASE_SERVICE_KEY` env var added to Vercel (no `NEXT_PUBLIC_` prefix = never exposed to browser)

## Security
- All admin routes already require GitHub auth via `requireAuth()` (checks session + username allowlist)
- Service role key is server-only — Next.js strips non-`NEXT_PUBLIC_` vars from client bundles
- No RLS policies were modified — tables remain locked down for any direct/anon access

## Test plan
- [x] All 17 tests pass
- [x] `SUPABASE_SERVICE_KEY` added to Vercel production + preview
- [ ] Verify dashboard loads data after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces use of the Supabase service-role key (bypasses RLS), so any auth/route exposure bug in admin server actions would become higher impact; changes are localized and remain behind existing `requireAuth()` checks.
> 
> **Overview**
> Fixes the admin golem dashboard returning empty data under RLS by switching server actions to use a **service-role Supabase client** instead of the anon/cookie-based client.
> 
> Adds `lib/supabase/admin.ts` with `createAdminClient()` (service key, no session persistence) and updates golem admin actions (`getOverviewStats`, `getEvents`, `getEmails`, `getGolemState`, `getOutreachData`, `getJobs`, `updateJobStatus`) to use it after `requireAuth()` gating.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9580d96e003cae617fbd7808d7bf71666a596599. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->