### PR TITLE
feat(admin): complete dashboard — bad match flow, pagination, typed constants

### DIFF
--- a/app/admin/golem/components/BadMatchModal.tsx
+++ b/app/admin/golem/components/BadMatchModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { X, AlertTriangle, Loader2 } from 'lucide-react';
 import { REJECTION_TAGS, type RejectionTag, rejectionTagLabels } from '../lib/constants';
 
@@ -15,6 +15,28 @@ export function BadMatchModal({ open, onClose, onConfirm, jobTitle }: BadMatchMo
   const [selectedTags, setSelectedTags] = useState<Set<RejectionTag>>(new Set());
   const [note, setNote] = useState('');
   const [saving, setSaving] = useState(false);
+
+  // Reset state when modal opens for a new job
+  useEffect(() => {
+    if (open) {
+      setSelectedTags(new Set());
+      setNote('');
+    }
+  }, [open, jobTitle]);
+
+  // Escape key handler
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape' && !saving) {
+      onClose();
+    }
+  }, [onClose, saving]);
+
+  useEffect(() => {
+    if (open) {
+      document.addEventListener('keydown', handleKeyDown);
+      return () => document.removeEventListener('keydown', handleKeyDown);
+    }
+  }, [open, handleKeyDown]);
 
   if (!open) return null;
 
@@ -37,8 +59,6 @@ export function BadMatchModal({ open, onClose, onConfirm, jobTitle }: BadMatchMo
         Array.from(selectedTags),
         note.trim() || null,
       );
-      setSelectedTags(new Set());
-      setNote('');
     } finally {
       setSaving(false);
     }

--- a/app/admin/golem/components/BadMatchModal.tsx
+++ b/app/admin/golem/components/BadMatchModal.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useState } from 'react';
+import { X, AlertTriangle, Loader2 } from 'lucide-react';
+import { REJECTION_TAGS, type RejectionTag, rejectionTagLabels } from '../lib/constants';
+
+interface BadMatchModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (tags: RejectionTag[], note: string | null) => Promise<void>;
+  jobTitle: string;
+}
+
+export function BadMatchModal({ open, onClose, onConfirm, jobTitle }: BadMatchModalProps) {
+  const [selectedTags, setSelectedTags] = useState<Set<RejectionTag>>(new Set());
+  const [note, setNote] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  if (!open) return null;
+
+  const toggleTag = (tag: RejectionTag) => {
+    setSelectedTags((prev) => {
+      const next = new Set(prev);
+      if (next.has(tag)) {
+        next.delete(tag);
+      } else {
+        next.add(tag);
+      }
+      return next;
+    });
+  };
+
+  const handleConfirm = async () => {
+    setSaving(true);
+    try {
+      await onConfirm(
+        Array.from(selectedTags),
+        note.trim() || null,
+      );
+      setSelectedTags(new Set());
+      setNote('');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget && !saving) {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm animate-in fade-in duration-200"
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Bad match: ${jobTitle}`}
+    >
+      <div className="w-full max-w-md mx-4 rounded-xl border border-white/10 bg-zinc-900 p-6 shadow-2xl animate-in zoom-in-95 duration-200">
+        {/* Header */}
+        <div className="flex items-start justify-between mb-4">
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-red-400" />
+            <h2 className="text-lg font-semibold text-white">Bad Match</h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="text-white/40 hover:text-white transition-colors disabled:opacity-30"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <p className="text-sm text-white/60 mb-4 line-clamp-2">{jobTitle}</p>
+
+        {/* Tag chips */}
+        <div className="mb-4">
+          <label className="text-xs text-white/50 mb-2 block">Why is this a bad match?</label>
+          <div className="flex flex-wrap gap-2">
+            {REJECTION_TAGS.map((tag) => {
+              const isSelected = selectedTags.has(tag);
+              return (
+                <button
+                  key={tag}
+                  type="button"
+                  onClick={() => toggleTag(tag)}
+                  disabled={saving}
+                  className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-all ${
+                    isSelected
+                      ? 'bg-red-500/20 text-red-300 border-red-500/40'
+                      : 'bg-white/5 text-white/60 border-white/10 hover:bg-white/10'
+                  } disabled:opacity-50`}
+                >
+                  {rejectionTagLabels[tag]}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Optional note */}
+        <div className="mb-6">
+          <label htmlFor="rejection-note" className="text-xs text-white/50 mb-2 block">
+            Additional notes (optional)
+          </label>
+          <textarea
+            id="rejection-note"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            disabled={saving}
+            placeholder="e.g., requires 10+ years of Go experience..."
+            className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-white/30 focus:border-white/30 focus:outline-none transition-colors resize-none disabled:opacity-50"
+            rows={2}
+          />
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-3 justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="px-4 py-2 rounded-lg text-sm text-white/60 hover:text-white hover:bg-white/5 transition-colors disabled:opacity-30"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={saving || selectedTags.size === 0}
+            className="px-4 py-2 rounded-lg text-sm font-medium bg-red-500/20 text-red-400 border border-red-500/30 hover:bg-red-500/30 transition-colors disabled:opacity-30 flex items-center gap-2"
+          >
+            {saving ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              'Mark Bad Match'
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/golem/components/RelevanceButtons.tsx
+++ b/app/admin/golem/components/RelevanceButtons.tsx
@@ -4,16 +4,17 @@ import { ThumbsDown, ThumbsUp } from 'lucide-react';
 
 type RelevanceButtonsProps = {
   value: boolean | null;
-  onVote: (relevant: boolean) => Promise<void>;
+  onGoodMatch: () => Promise<void>;
+  onBadMatch: () => void;
   saving?: boolean;
 };
 
-export function RelevanceButtons({ value, onVote, saving = false }: RelevanceButtonsProps) {
+export function RelevanceButtons({ value, onGoodMatch, onBadMatch, saving = false }: RelevanceButtonsProps) {
   return (
     <>
       <button
         type="button"
-        onClick={() => onVote(true)}
+        onClick={onGoodMatch}
         disabled={saving}
         className={`inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 ${
           value === true
@@ -26,7 +27,7 @@ export function RelevanceButtons({ value, onVote, saving = false }: RelevanceBut
       </button>
       <button
         type="button"
-        onClick={() => onVote(false)}
+        onClick={onBadMatch}
         disabled={saving}
         className={`inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 ${
           value === false

--- a/app/admin/golem/components/index.ts
+++ b/app/admin/golem/components/index.ts
@@ -1,3 +1,4 @@
+export { BadMatchModal } from './BadMatchModal';
 export { CategoryBadge } from './CategoryBadge';
 export { CorrectionBanner } from './CorrectionBanner';
 export { ListDetailLayout } from './ListDetailLayout';

--- a/app/admin/golem/jobs/actions/jobs.ts
+++ b/app/admin/golem/jobs/actions/jobs.ts
@@ -4,7 +4,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/app/lib/auth';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { escapePostgrestSearch } from './utils';
-import type { JobStatus, RejectionTag } from '../../lib/constants';
+import { REJECTION_TAGS, type JobStatus, type RejectionTag } from '../../lib/constants';
 
 // Verify session before any operation
 async function requireAuth() {
@@ -168,6 +168,17 @@ export async function saveJobRejection(
 ): Promise<{ success: boolean; error: string | null }> {
   try {
     await requireAuth();
+
+    if (!jobId || typeof jobId !== 'string') {
+      return { success: false, error: 'Invalid job ID' };
+    }
+    if (!Array.isArray(tags) || tags.length === 0) {
+      return { success: false, error: 'At least one rejection tag is required' };
+    }
+    const validTags = new Set<string>(REJECTION_TAGS);
+    if (tags.some((t) => !validTags.has(t))) {
+      return { success: false, error: 'Invalid rejection tag' };
+    }
 
     const supabase = createAdminClient();
 

--- a/app/admin/golem/jobs/actions/jobs.ts
+++ b/app/admin/golem/jobs/actions/jobs.ts
@@ -4,6 +4,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/app/lib/auth';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { escapePostgrestSearch } from './utils';
+import type { JobStatus, RejectionTag } from '../../lib/constants';
 
 // Verify session before any operation
 async function requireAuth() {
@@ -11,7 +12,7 @@ async function requireAuth() {
   if (!session) {
     throw new Error('Unauthorized');
   }
-  
+
   // Extra check: verify username is allowed
   const allowedUsernames = process.env.ALLOWED_GITHUB_USERNAMES?.split(',') || [];
   if (allowedUsernames.length > 0) {
@@ -20,7 +21,7 @@ async function requireAuth() {
       throw new Error('Forbidden');
     }
   }
-  
+
   return session;
 }
 
@@ -46,6 +47,15 @@ export interface Job {
   human_match_score: number | null;
   human_relevant: boolean | null;
   corrected_at: string | null;
+  rejection_tags: RejectionTag[] | null;
+  rejection_note: string | null;
+}
+
+export interface JobsResponse {
+  jobs: Job[];
+  total: number;
+  statusCounts: Record<string, number>;
+  error: string | null;
 }
 
 export async function getJobs(filters?: {
@@ -54,7 +64,8 @@ export async function getJobs(filters?: {
   search?: string;
   page?: number;
   pageSize?: number;
-}): Promise<{ jobs: Job[]; total: number; error: string | null }> {
+  includeArchived?: boolean;
+}): Promise<JobsResponse> {
   try {
     await requireAuth();
 
@@ -63,12 +74,19 @@ export async function getJobs(filters?: {
     const pageSize = filters?.pageSize ?? 100;
     const from = page * pageSize;
     const to = from + pageSize - 1;
+    const includeArchived = filters?.includeArchived ?? false;
 
+    // Main query for paginated results
     let query = supabase
       .from('golem_jobs')
       .select('*', { count: 'exact' })
       .order('scraped_at', { ascending: false })
       .range(from, to);
+
+    // Exclude archived by default unless explicitly requested
+    if (!includeArchived && (!filters?.status || filters.status === 'all')) {
+      query = query.neq('status', 'archived');
+    }
 
     if (filters?.status && filters.status !== 'all') {
       query = query.eq('status', filters.status);
@@ -81,21 +99,37 @@ export async function getJobs(filters?: {
       query = query.or(`title.ilike.%${escaped}%,company.ilike.%${escaped}%`);
     }
 
-    const { data, count, error } = await query;
+    // Separate query for global status counts (across ALL jobs, no pagination)
+    const [mainResult, countResult] = await Promise.all([
+      query,
+      supabase.from('golem_jobs').select('status'),
+    ]);
 
-    if (error) {
-      console.error('Supabase error:', error);
-      return { jobs: [], total: 0, error: error.message };
+    if (mainResult.error) {
+      console.error('Supabase error:', mainResult.error);
+      return { jobs: [], total: 0, statusCounts: {}, error: mainResult.error.message };
     }
 
-    return { jobs: data || [], total: count ?? 0, error: null };
+    // Aggregate status counts client-side
+    const statusCounts: Record<string, number> = {};
+    for (const row of (countResult.data || []) as { status: string | null }[]) {
+      const status = row.status || 'unknown';
+      statusCounts[status] = (statusCounts[status] || 0) + 1;
+    }
+
+    return {
+      jobs: mainResult.data || [],
+      total: mainResult.count ?? 0,
+      statusCounts,
+      error: null,
+    };
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
-    return { jobs: [], total: 0, error: message };
+    return { jobs: [], total: 0, statusCounts: {}, error: message };
   }
 }
 
-const VALID_STATUSES = ['new', 'viewed', 'saved', 'applied', 'rejected', 'archived'] as const;
+const VALID_STATUSES = ['new', 'viewed', 'saved', 'applied', 'archived'] as const;
 type ValidStatus = (typeof VALID_STATUSES)[number];
 
 export async function updateJobStatus(
@@ -110,10 +144,42 @@ export async function updateJobStatus(
     }
 
     const supabase = createAdminClient();
-    
+
     const { error } = await supabase
       .from('golem_jobs')
       .update({ status })
+      .eq('id', jobId);
+
+    if (error) {
+      return { success: false, error: error.message };
+    }
+
+    return { success: true, error: null };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return { success: false, error: message };
+  }
+}
+
+export async function saveJobRejection(
+  jobId: string,
+  tags: RejectionTag[],
+  note: string | null,
+): Promise<{ success: boolean; error: string | null }> {
+  try {
+    await requireAuth();
+
+    const supabase = createAdminClient();
+
+    const { error } = await supabase
+      .from('golem_jobs')
+      .update({
+        status: 'archived',
+        rejection_tags: tags,
+        rejection_note: note || null,
+        human_relevant: false,
+        corrected_at: new Date().toISOString(),
+      })
       .eq('id', jobId);
 
     if (error) {

--- a/app/admin/golem/jobs/page.tsx
+++ b/app/admin/golem/jobs/page.tsx
@@ -289,7 +289,8 @@ export default function JobsPage() {
         <div className="shrink-0 flex flex-wrap gap-2 mb-4">
           <RelevanceButtons
             value={job.human_relevant}
-            onVote={handleRelevance}
+            onGoodMatch={() => handleRelevance(true)}
+            onBadMatch={() => setBadMatchJob(job)}
             saving={saving}
           />
 
@@ -322,16 +323,6 @@ export default function JobsPage() {
             >
               <Check className="h-4 w-4" />
               Applied
-            </button>
-          )}
-          {job.status !== 'archived' && (
-            <button
-              type="button"
-              onClick={() => setBadMatchJob(job)}
-              className="inline-flex items-center gap-2 rounded-lg border border-red-500/50 text-red-400 px-4 py-2 text-sm font-medium hover:bg-red-500/10 transition-colors"
-            >
-              <ThumbsDown className="h-4 w-4" />
-              Bad Match
             </button>
           )}
         </div>

--- a/app/admin/golem/jobs/page.tsx
+++ b/app/admin/golem/jobs/page.tsx
@@ -879,21 +879,12 @@ export default function JobsPage() {
         onConfirm={async (tags: RejectionTag[], note: string | null) => {
           if (!badMatchJob) return;
           const { success } = await saveJobRejection(badMatchJob.id, tags, note);
-          if (success) {
-            const updated = {
-              ...badMatchJob,
-              status: 'archived',
-              rejection_tags: tags,
-              rejection_note: note,
-              human_relevant: false,
-              corrected_at: new Date().toISOString(),
-            };
-            setJobs((prev) => prev.filter((j) => j.id !== badMatchJob.id));
-            if (selectedJob?.id === badMatchJob.id) {
-              setSelectedJob(null);
-            }
-            setBadMatchJob(null);
+          if (!success) return;
+          setJobs((prev) => prev.filter((j) => j.id !== badMatchJob.id));
+          if (selectedJob?.id === badMatchJob.id) {
+            setSelectedJob(null);
           }
+          setBadMatchJob(null);
         }}
       />
     </div>

--- a/app/admin/golem/lib/constants.ts
+++ b/app/admin/golem/lib/constants.ts
@@ -1,9 +1,13 @@
 import type { LucideIcon } from 'lucide-react';
-import { Archive, Bookmark, Eye, Send, Star, X } from 'lucide-react';
+import { Archive, Bookmark, Eye, Send, Star } from 'lucide-react';
 
 // --- Email ---
 
-export const categoryColors: Record<string, string> = {
+export type EmailCategory =
+  | 'urgent' | 'tech-update' | 'job' | 'interview' | 'newsletter'
+  | 'promo' | 'subscription' | 'social' | 'github' | 'other';
+
+export const categoryColors: Record<EmailCategory, string> = {
   urgent: 'bg-red-500/20 text-red-400 border-red-500/30',
   'tech-update': 'bg-violet-500/20 text-violet-400 border-violet-500/30',
   job: 'bg-emerald-500/20 text-emerald-400 border-emerald-500/30',
@@ -12,12 +16,13 @@ export const categoryColors: Record<string, string> = {
   promo: 'bg-gray-500/20 text-gray-400 border-gray-500/30',
   subscription: 'bg-amber-500/20 text-amber-400 border-amber-500/30',
   social: 'bg-pink-500/20 text-pink-400 border-pink-500/30',
+  github: 'bg-slate-500/20 text-slate-400 border-slate-500/30',
   other: 'bg-zinc-500/20 text-zinc-400 border-zinc-500/30',
 };
 
-export const EMAIL_CATEGORIES = [
+export const EMAIL_CATEGORIES: EmailCategory[] = [
   'urgent', 'tech-update', 'job', 'interview', 'newsletter',
-  'promo', 'subscription', 'social', 'other',
+  'promo', 'subscription', 'social', 'github', 'other',
 ];
 
 export function scoreColor(score: number | null): string {
@@ -30,14 +35,13 @@ export function scoreColor(score: number | null): string {
 
 // --- Jobs ---
 
-export type JobStatus = 'new' | 'viewed' | 'saved' | 'applied' | 'rejected' | 'archived';
+export type JobStatus = 'new' | 'viewed' | 'saved' | 'applied' | 'archived';
 
 export const statusConfig: Record<JobStatus, { label: string; color: string; cardBorder: string; icon: LucideIcon }> = {
   new: { label: 'New', color: 'bg-blue-500/20 text-blue-400 border-blue-500/30', cardBorder: 'border-l-blue-500', icon: Star },
   viewed: { label: 'Viewed', color: 'bg-gray-500/20 text-gray-400 border-gray-500/30', cardBorder: 'border-l-gray-500', icon: Eye },
   saved: { label: 'Saved', color: 'bg-amber-500/20 text-amber-400 border-amber-500/30', cardBorder: 'border-l-amber-500', icon: Bookmark },
   applied: { label: 'Applied', color: 'bg-emerald-500/20 text-emerald-400 border-emerald-500/30', cardBorder: 'border-l-emerald-500', icon: Send },
-  rejected: { label: 'Rejected', color: 'bg-red-500/20 text-red-400 border-red-500/30', cardBorder: 'border-l-red-500', icon: X },
   archived: { label: 'Archived', color: 'bg-zinc-500/20 text-zinc-400 border-zinc-500/30', cardBorder: 'border-l-zinc-500', icon: Archive },
 };
 
@@ -46,8 +50,32 @@ export const statusPriority: Record<JobStatus, number> = {
   saved: 2,
   new: 3,
   viewed: 4,
-  rejected: 5,
-  archived: 6,
+  archived: 5,
+};
+
+// Rejection reason tags for bad match feedback
+export const REJECTION_TAGS = [
+  'wrong-stack',
+  'too-senior',
+  'too-junior',
+  'wrong-location',
+  'low-salary',
+  'not-relevant',
+  'bad-company',
+  'other',
+] as const;
+
+export type RejectionTag = (typeof REJECTION_TAGS)[number];
+
+export const rejectionTagLabels: Record<RejectionTag, string> = {
+  'wrong-stack': 'Wrong Tech Stack',
+  'too-senior': 'Too Senior',
+  'too-junior': 'Too Junior',
+  'wrong-location': 'Wrong Location',
+  'low-salary': 'Low Salary',
+  'not-relevant': 'Not Relevant',
+  'bad-company': 'Bad Company',
+  'other': 'Other',
 };
 
 export const sourceConfig: Record<string, { label: string; color: string }> = {

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -1,0 +1,37 @@
+# Admin Dashboard Completion
+
+> Fix all dashboard UX issues: categories, pagination, job workflow, feedback loop.
+
+## Progress
+
+| # | Phase | Folder | Status | Notes |
+|---|-------|--------|--------|-------|
+| 1 | Foundation | [phase-1](phase-1/) | 🏗️ | Supabase migration done, constants typed |
+| 2 | Jobs Overhaul | [phase-2](phase-2/) | ⏳ | Bad match modal, hide archived, sort, warnings |
+| 3 | Emails | [phase-3](phase-3/) | ⏳ | Category normalization, pagination |
+
+**Branch:** `fix/admin-dashboard-complete`
+**Repo:** etanheyman.com
+**Scraper fix:** golems issue #72 (separate)
+
+## Execution Rules
+
+- **CLI agents first:** cursor for code gen, gemini for research
+- **One branch, one PR** — all phases ship together
+- Everything typed (no `Record<string, string>` when we know the keys)
+- Tests for all new server actions
+
+## Research Findings
+
+### Email Categories (after DB normalization)
+promo(102), tech-update(63), newsletter(62), other(41), job(33), github(30), social(3), urgent(3), subscription(1)
+
+### Job Stats
+156 total: new(121), rejected→archived(21), viewed(10), applied(4)
+Drushim: 17/52 generic titles. SecretTLV: 35/35 no description.
+
+### Decision: Simplify Job Workflow
+- Remove "rejected" status → bad match (thumbs down) auto-archives
+- Tag modal on bad match with reason tags
+- Default view hides archived
+- Default sort = date

--- a/docs/plan/phase-1/README.md
+++ b/docs/plan/phase-1/README.md
@@ -1,0 +1,22 @@
+# Phase 1: Foundation
+
+> [Back to main plan](../README.md)
+
+## Goal
+Database migrations, typed constants, server-side job counts.
+
+## Tools
+- **Code:** Opus orchestration + cursor for server actions
+- **DB:** Supabase MCP for migrations
+
+## Steps
+1. Supabase migration: normalize email categories + add rejection_tags/rejection_note columns
+2. Type constants.ts: EmailCategory type, RejectionTag type, remove "rejected" JobStatus
+3. Update jobs server action: add statusCounts to response, exclude archived by default
+4. Update emails server action: add pagination (page/pageSize params)
+
+## Status
+- [x] Supabase migration applied
+- [x] Constants typed (EmailCategory, RejectionTag, JobStatus simplified)
+- [ ] Jobs server action: statusCounts + exclude archived
+- [ ] Emails server action: pagination

--- a/docs/plan/phase-1/findings.md
+++ b/docs/plan/phase-1/findings.md
@@ -1,0 +1,12 @@
+# Phase 1 Findings
+
+## Decisions
+
+## Research
+
+## Task Board
+
+| Task | Owner | Status |
+|------|-------|--------|
+
+## Notes

--- a/docs/plan/phase-2/README.md
+++ b/docs/plan/phase-2/README.md
@@ -1,0 +1,30 @@
+# Phase 2: Jobs Overhaul
+
+> [Back to main plan](../README.md)
+
+## Goal
+Rework job page: bad match modal, hide archived, date sort default, warning badges.
+
+## Tools
+- **Code:** cursor for component generation, Opus for wiring
+
+## Steps
+1. Create BadMatchModal component (tag chips + optional note + confirm)
+2. Wire bad match flow: thumbs down → modal → save tags + auto-archive
+3. Default view excludes archived; add Archive tab
+4. Default sort = date
+5. Warning badge on jobs with no description or generic "Job #" titles
+6. Remove "Reject" button, replace with bad match in RelevanceButtons
+7. Server action: saveJobRejection(jobId, tags, note) → sets archived + tags
+
+## Depends On
+- Phase 1 (constants + server actions)
+
+## Status
+- [ ] BadMatchModal component
+- [ ] Bad match flow wiring
+- [ ] Hide archived from default
+- [ ] Default sort = date
+- [ ] Warning badges
+- [ ] Replace reject button
+- [ ] Server action for rejection

--- a/docs/plan/phase-2/findings.md
+++ b/docs/plan/phase-2/findings.md
@@ -1,0 +1,12 @@
+# Phase 2 Findings
+
+## Decisions
+
+## Research
+
+## Task Board
+
+| Task | Owner | Status |
+|------|-------|--------|
+
+## Notes

--- a/docs/plan/phase-3/README.md
+++ b/docs/plan/phase-3/README.md
@@ -1,0 +1,22 @@
+# Phase 3: Emails
+
+> [Back to main plan](../README.md)
+
+## Goal
+Email page gets pagination and uses normalized categories.
+
+## Tools
+- **Code:** cursor for pagination component
+
+## Steps
+1. Add pagination to emails page (reuse jobs pagination pattern)
+2. Verify category dropdown includes 'github'
+3. Show total count from server (not array length)
+
+## Depends On
+- Phase 1 (emails server action pagination)
+
+## Status
+- [ ] Email pagination UI
+- [ ] Category dropdown verified
+- [ ] Total count from server

--- a/docs/plan/phase-3/findings.md
+++ b/docs/plan/phase-3/findings.md
@@ -1,0 +1,12 @@
+# Phase 3 Findings
+
+## Decisions
+
+## Research
+
+## Task Board
+
+| Task | Owner | Status |
+|------|-------|--------|
+
+## Notes

--- a/middleware.ts
+++ b/middleware.ts
@@ -39,8 +39,14 @@ export async function middleware(request: NextRequest) {
     }
   }
 
-  // Get country from Vercel's geolocation
-  const { country = 'US' } = geolocation(request);
+  // Get country from Vercel's geolocation (safe fallback for local dev)
+  let country = 'US';
+  try {
+    const geo = geolocation(request);
+    country = geo.country ?? 'US';
+  } catch {
+    // geolocation unavailable outside Vercel
+  }
 
   // Create response
   const response = NextResponse.next();


### PR DESCRIPTION
## Summary

- **Bad match flow**: Replaces "rejected" status with good match/bad match UX. Bad match opens a modal with rejection tags (wrong stack, too senior, location, etc.) + optional notes, then auto-archives the job
- **Server-side status counts**: Filter chips now show accurate counts across all pages, not just current page
- **Email pagination**: Server-side pagination with page/pageSize params, prev/next UI, total count
- **Default sort by date**: Jobs now sort by received date instead of priority
- **Weak data warnings**: Jobs with generic "Job #" titles or missing descriptions show AlertTriangle badge
- **Typed constants**: `EmailCategory`, `RejectionTag`, `JobStatus` union types replace inline strings
- **DB migrations**: Normalized email categories (GitHub variants → `github`), added `rejection_tags`/`rejection_note` columns, migrated 21 rejected → archived

## What changed

| Area | Change |
|------|--------|
| `lib/constants.ts` | `EmailCategory`, `RejectionTag` types, rejection tag labels, removed `rejected` status |
| `jobs/actions/jobs.ts` | `JobsResponse` with statusCounts, `saveJobRejection()`, `includeArchived` filter |
| `jobs/page.tsx` | Bad match modal, archive tab, weak data badges, server-side counts |
| `actions/data.ts` | `getEmails` with pagination (page/pageSize/total) |
| `emails/page.tsx` | Pagination state + UI (prev/next, page X of Y) |
| `components/BadMatchModal.tsx` | New: tag chips, notes field, loading state |
| `__tests__/data.test.ts` | Updated mocks for pagination return shape |

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] All 40 tests pass (`vitest run`)
- [ ] Verify bad match modal opens on thumbs down, saves tags + archives job
- [x] Verify archived jobs hidden from default view, visible in Archive tab
- [x] Verify email pagination works (prev/next, page count)
- [x] Verify status count chips show correct totals

Related: #72 (scraper fix for generic job titles — separate concern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core admin triage flows and Supabase queries (pagination, archived filtering, job state updates), so regressions could hide items or miscount results, but changes are scoped to admin-only features.
> 
> **Overview**
> Improves the admin golem dashboard with **paginated email triage**: `getEmails` now uses `page`/`pageSize`, returns `total` via `count: 'exact'`, and the UI adds prev/next controls while showing total results.
> 
> Reworks the jobs workflow to **replace “rejected” with an archive-based bad match flow**: adds `BadMatchModal` with rejection tags + optional note, a new `saveJobRejection` server action that validates tags and updates `golem_jobs` (sets `status: 'archived'`, stores tags/note, and marks `human_relevant=false`), and updates `RelevanceButtons`/jobs page to trigger the modal and remove the old reject action. Jobs fetching now **hides archived by default**, adds an Archive chip, and returns **server-computed status counts** for accurate filter totals across pages; the UI also defaults sort to date and flags “weak data” jobs with a warning badge.
> 
> Also tightens typing in `constants` (typed `EmailCategory` incl. `github`, `JobStatus` without `rejected`, and `RejectionTag` set/labels), updates tests for the new email pagination return shape, and makes `middleware.ts` geolocation lookup resilient outside Vercel.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49c0c82794e5665aaa4af670bec25a40008f3e15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email list: pagination controls and total count display.
  * Bad Match modal to flag/archive jobs with rejection tags and optional note.
  * New "github" email category and updated category colors.

* **Improvements**
  * Job list excludes archived by default; Archive filter added and default sort set to date.
  * Job status counts provided by server; weak-data warning shown on jobs.
  * Relevance buttons split into explicit Good/Bad actions.

* **Tests**
  * Tests updated for total counts and new pagination semantics.

* **Documentation**
  * Added admin dashboard planning (phase docs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->