### PR TITLE
fix(admin): usage stats field name mismatch with backend

### DIFF
--- a/app/admin/golem/actions/data.ts
+++ b/app/admin/golem/actions/data.ts
@@ -86,14 +86,13 @@ export interface UsageBySource {
   calls: number;
   inputTokens: number;
   outputTokens: number;
-  costUsd: number;
 }
 
 export interface UsageStats {
   totalCalls: number;
   totalInputTokens: number;
   totalOutputTokens: number;
-  totalCostUsd: number;
+  estimatedCostUSD: number;
   bySource: Record<string, UsageBySource>;
 }
 

--- a/app/admin/golem/page.tsx
+++ b/app/admin/golem/page.tsx
@@ -181,7 +181,7 @@ export default function GolemOverview() {
             <div className="rounded-lg border border-white/10 bg-white/5 p-3 text-center">
               <div className="text-lg font-bold text-white flex items-center justify-center gap-1">
                 <DollarSign className="h-4 w-4 text-emerald-400" />
-                {(stats.usageStats.totalCostUsd ?? 0).toFixed(4)}
+                {(stats.usageStats.estimatedCostUSD ?? 0).toFixed(4)}
               </div>
               <div className="text-[10px] uppercase tracking-wider text-white/50">Total Cost</div>
             </div>
@@ -205,7 +205,7 @@ export default function GolemOverview() {
                       <td className="py-2 px-3 text-right text-white/60 tabular-nums">{data.calls}</td>
                       <td className="py-2 px-3 text-right text-white/60 tabular-nums">{formatTokens(data.inputTokens)}</td>
                       <td className="py-2 px-3 text-right text-white/60 tabular-nums">{formatTokens(data.outputTokens)}</td>
-                      <td className="py-2 px-3 text-right text-white/60 tabular-nums">${(data.costUsd ?? 0).toFixed(4)}</td>
+                      <td className="py-2 px-3 text-right text-white/60 tabular-nums">${((data.inputTokens * 0.8 + data.outputTokens * 4.0) / 1_000_000).toFixed(4)}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/app/admin/golem/page.tsx
+++ b/app/admin/golem/page.tsx
@@ -167,26 +167,26 @@ export default function GolemOverview() {
           </h2>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
             <div className="rounded-lg border border-white/10 bg-white/5 p-3 text-center">
-              <div className="text-lg font-bold text-white">{stats.usageStats.totalCalls}</div>
+              <div className="text-lg font-bold text-white">{stats.usageStats.totalCalls ?? 0}</div>
               <div className="text-[10px] uppercase tracking-wider text-white/50">API Calls</div>
             </div>
             <div className="rounded-lg border border-white/10 bg-white/5 p-3 text-center">
-              <div className="text-lg font-bold text-white">{formatTokens(stats.usageStats.totalInputTokens)}</div>
+              <div className="text-lg font-bold text-white">{formatTokens(stats.usageStats.totalInputTokens ?? 0)}</div>
               <div className="text-[10px] uppercase tracking-wider text-white/50">Input Tokens</div>
             </div>
             <div className="rounded-lg border border-white/10 bg-white/5 p-3 text-center">
-              <div className="text-lg font-bold text-white">{formatTokens(stats.usageStats.totalOutputTokens)}</div>
+              <div className="text-lg font-bold text-white">{formatTokens(stats.usageStats.totalOutputTokens ?? 0)}</div>
               <div className="text-[10px] uppercase tracking-wider text-white/50">Output Tokens</div>
             </div>
             <div className="rounded-lg border border-white/10 bg-white/5 p-3 text-center">
               <div className="text-lg font-bold text-white flex items-center justify-center gap-1">
                 <DollarSign className="h-4 w-4 text-emerald-400" />
-                {stats.usageStats.totalCostUsd.toFixed(4)}
+                {(stats.usageStats.totalCostUsd ?? 0).toFixed(4)}
               </div>
               <div className="text-[10px] uppercase tracking-wider text-white/50">Total Cost</div>
             </div>
           </div>
-          {Object.keys(stats.usageStats.bySource).length > 0 && (
+          {stats.usageStats.bySource && Object.keys(stats.usageStats.bySource).length > 0 && (
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
@@ -205,7 +205,7 @@ export default function GolemOverview() {
                       <td className="py-2 px-3 text-right text-white/60 tabular-nums">{data.calls}</td>
                       <td className="py-2 px-3 text-right text-white/60 tabular-nums">{formatTokens(data.inputTokens)}</td>
                       <td className="py-2 px-3 text-right text-white/60 tabular-nums">{formatTokens(data.outputTokens)}</td>
-                      <td className="py-2 px-3 text-right text-white/60 tabular-nums">${data.costUsd.toFixed(4)}</td>
+                      <td className="py-2 px-3 text-right text-white/60 tabular-nums">${(data.costUsd ?? 0).toFixed(4)}</td>
                     </tr>
                   ))}
                 </tbody>


### PR DESCRIPTION
## Summary

- Root cause: backend `/usage` returns `estimatedCostUSD`, frontend expected `totalCostUsd`
- Per-source data has no `costUsd` — now computed inline from token counts (Haiku pricing)
- Also adds null-safety fallbacks for all usage stat fields

## Test plan

- [x] 40 tests pass
- [ ] Admin dashboard loads without TypeError on `/admin/golem`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only/admin-only type and rendering changes; primary risk is misreporting usage cost if the inline pricing formula is wrong or backend fields change again.
> 
> **Overview**
> Fixes a frontend/backend mismatch in `/admin/golem` usage stats by renaming `totalCostUsd` to `estimatedCostUSD` and dropping the per-source `costUsd` field from the typed data model.
> 
> Updates the dashboard rendering to be null-safe for usage counters, guards access to `bySource`, and computes per-source cost inline from token counts (Haiku pricing) so the page no longer throws when the backend omits those fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8afee0e827297d64ca117178bbd71b39b5c24fa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->