### PR TITLE
feat(admin): Job Search Command Center frontend

### DIFF
--- a/app/admin/golem/layout.tsx
+++ b/app/admin/golem/layout.tsx
@@ -3,7 +3,7 @@
 import { useSession } from 'next-auth/react';
 import { useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
-import { LayoutDashboard, Briefcase, Bell, Moon, FileText, Mail, Users, ArrowLeft, Bot } from 'lucide-react';
+import { LayoutDashboard, Briefcase, Bell, Moon, Mail, Users, ArrowLeft, Bot } from 'lucide-react';
 import { useEffect } from 'react';
 
 const navItems = [
@@ -11,9 +11,8 @@ const navItems = [
   { href: '/admin/golem/jobs', label: 'Jobs', icon: Briefcase },
   { href: '/admin/golem/emails', label: 'Emails', icon: Mail },
   { href: '/admin/golem/alerts', label: 'Activity', icon: Bell },
-  { href: '/admin/golem/outreach', label: 'Outreach', icon: Users },
+  { href: '/admin/golem/outreach', label: 'Connections', icon: Users },
   { href: '/admin/golem/nightshift', label: 'Night Shift', icon: Moon },
-  { href: '/admin/golem/content', label: 'Content', icon: FileText },
 ];
 
 export default function GolemLayout({

--- a/app/admin/golem/outreach/page.tsx
+++ b/app/admin/golem/outreach/page.tsx
@@ -56,14 +56,6 @@ export default function ConnectionsPage() {
   const connectionMatches = (connectionId: string) =>
     matches.filter((m) => m.connection_id === connectionId);
 
-  const matchesByJob = new Map<string, ConnectionMatch[]>();
-  for (const m of matches) {
-    if (!m.job) continue;
-    const existing = matchesByJob.get(m.job_id) || [];
-    existing.push(m);
-    matchesByJob.set(m.job_id, existing);
-  }
-
   return (
     <div className="flex h-full flex-col overflow-hidden">
       {/* Header */}
@@ -256,7 +248,7 @@ export default function ConnectionsPage() {
                             {Math.round(match.match_confidence * 100)}% confidence
                           </span>
                         </div>
-                        {match.job?.match_score && (
+                        {match.job?.match_score != null && (
                           <span className={`text-xs font-medium ${
                             match.job.match_score >= 7 ? 'text-emerald-400' :
                             match.job.match_score >= 4 ? 'text-amber-400' : 'text-white/40'

--- a/app/admin/golem/outreach/page.tsx
+++ b/app/admin/golem/outreach/page.tsx
@@ -1,57 +1,78 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { getOutreachData, type OutreachContact, type OutreachMessage } from '../actions/data';
-import { Users, RefreshCw, Send, ExternalLink, Building2 } from 'lucide-react';
+import {
+  getLinkedInConnections,
+  getConnectionMatches,
+  type LinkedInConnection,
+  type ConnectionMatch,
+} from '../actions/data';
+import {
+  Users,
+  RefreshCw,
+  ExternalLink,
+  Building2,
+  Search,
+  Briefcase,
+  MessageCircle,
+  Link2,
+} from 'lucide-react';
 
-const statusColors: Record<string, string> = {
-  draft: 'bg-zinc-500/20 text-zinc-400',
-  sent: 'bg-blue-500/20 text-blue-400',
-  replied: 'bg-emerald-500/20 text-emerald-400',
-  bounced: 'bg-red-500/20 text-red-400',
-  pending: 'bg-amber-500/20 text-amber-400',
-};
-
-function formatDate(date: string): string {
+function formatDate(date: string | null): string {
+  if (!date) return '';
   const d = new Date(date);
-  const now = new Date();
-  const diffMs = now.getTime() - d.getTime();
-  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-  if (diffHours < 1) return 'Just now';
-  if (diffHours < 24) return `${diffHours}h ago`;
-  const diffDays = Math.floor(diffHours / 24);
-  if (diffDays < 7) return `${diffDays}d ago`;
-  return d.toLocaleDateString();
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
 }
 
-export default function OutreachPage() {
-  const [contacts, setContacts] = useState<OutreachContact[]>([]);
-  const [messages, setMessages] = useState<OutreachMessage[]>([]);
+const matchTypeColors: Record<string, string> = {
+  exact: 'bg-emerald-500/20 text-emerald-400',
+  substring: 'bg-blue-500/20 text-blue-400',
+  fuzzy: 'bg-amber-500/20 text-amber-400',
+};
+
+export default function ConnectionsPage() {
+  const [connections, setConnections] = useState<LinkedInConnection[]>([]);
+  const [matches, setMatches] = useState<ConnectionMatch[]>([]);
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [selectedContact, setSelectedContact] = useState<OutreachContact | null>(null);
+  const [search, setSearch] = useState('');
+  const [selectedConnection, setSelectedConnection] = useState<LinkedInConnection | null>(null);
+  const [messagesOnly, setMessagesOnly] = useState(false);
 
   const refresh = async () => {
     setLoading(true);
-    const { contacts: c, messages: m } = await getOutreachData();
-    setContacts(c);
-    setMessages(m);
+    const [connResult, matchResult] = await Promise.all([
+      getLinkedInConnections({ search, hasMessages: messagesOnly || undefined }),
+      getConnectionMatches(),
+    ]);
+    setConnections(connResult.connections);
+    setTotal(connResult.total);
+    setMatches(matchResult.matches);
     setLoading(false);
   };
 
-  useEffect(() => { refresh(); }, []);
+  useEffect(() => { refresh(); }, [search, messagesOnly]);
 
-  const contactMessages = (contactId: string) =>
-    messages.filter((m) => m.contact_id === contactId);
+  const connectionMatches = (connectionId: string) =>
+    matches.filter((m) => m.connection_id === connectionId);
+
+  const matchesByJob = new Map<string, ConnectionMatch[]>();
+  for (const m of matches) {
+    if (!m.job) continue;
+    const existing = matchesByJob.get(m.job_id) || [];
+    existing.push(m);
+    matchesByJob.set(m.job_id, existing);
+  }
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
       {/* Header */}
       <div className="shrink-0 flex items-center justify-between pb-4">
         <h1 className="text-lg font-semibold text-white flex items-center gap-2">
-          <Users className="h-5 w-5 text-emerald-400" />
-          Outreach Pipeline
+          <Users className="h-5 w-5 text-amber-400" />
+          LinkedIn Connections
           <span className="text-sm font-normal text-white/40">
-            ({contacts.length} contacts, {messages.length} messages)
+            ({total} connections, {matches.length} job matches)
           </span>
         </h1>
         <button
@@ -63,54 +84,89 @@ export default function OutreachPage() {
         </button>
       </div>
 
+      {/* Search + Filters */}
+      <div className="shrink-0 flex items-center gap-3 pb-4">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-white/30" />
+          <input
+            type="text"
+            placeholder="Search by name, company, position..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full rounded-lg border border-white/10 bg-white/5 py-2 pl-10 pr-4 text-sm text-white placeholder-white/30 focus:border-white/20 focus:outline-none"
+          />
+        </div>
+        <button
+          onClick={() => setMessagesOnly(!messagesOnly)}
+          className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors ${
+            messagesOnly
+              ? 'border-amber-500/30 bg-amber-500/10 text-amber-300'
+              : 'border-white/10 text-white/60 hover:bg-white/5'
+          }`}
+        >
+          <MessageCircle className="h-4 w-4" />
+          With Messages
+        </button>
+      </div>
+
       {/* Content */}
       <div className="flex-1 flex gap-4 min-h-0 overflow-hidden">
-        {/* Contacts List */}
-        <div className={`${selectedContact ? 'hidden md:flex' : 'flex'} w-full md:w-[360px] md:shrink-0 flex-col min-h-0 md:border-r md:border-white/10 md:pr-4`}>
+        {/* Connections List */}
+        <div className={`${selectedConnection ? 'hidden md:flex' : 'flex'} w-full md:w-[360px] md:shrink-0 flex-col min-h-0 md:border-r md:border-white/10 md:pr-4`}>
           <div className="flex-1 overflow-y-auto space-y-2">
             {loading ? (
               <div className="flex items-center justify-center py-12">
                 <RefreshCw className="h-6 w-6 text-white/40 animate-spin" />
               </div>
-            ) : contacts.length === 0 ? (
+            ) : connections.length === 0 ? (
               <div className="text-center py-12 text-white/50">
                 <Users className="h-12 w-12 mx-auto mb-3 opacity-50" />
-                <p>No contacts yet</p>
+                <p>No connections found</p>
               </div>
             ) : (
-              contacts.map((contact) => {
-                const msgs = contactMessages(contact.id);
+              connections.map((conn) => {
+                const jobMatches = connectionMatches(conn.id);
                 return (
                   <button
-                    key={contact.id}
+                    key={conn.id}
                     type="button"
-                    onClick={() => setSelectedContact(contact)}
+                    onClick={() => setSelectedConnection(conn)}
                     className={`w-full text-left p-3 rounded-lg border transition-all ${
-                      selectedContact?.id === contact.id
+                      selectedConnection?.id === conn.id
                         ? 'bg-white/10 border-white/30'
                         : 'bg-white/5 border-white/10 hover:bg-white/[0.07]'
                     }`}
                   >
                     <div className="flex items-start justify-between gap-2 mb-1">
-                      <p className="text-sm text-white font-medium truncate flex-1">{contact.name}</p>
-                      {msgs.length > 0 && (
-                        <span className="text-[10px] text-white/40 bg-white/10 rounded-full px-1.5 py-0.5">
-                          {msgs.length} msg{msgs.length !== 1 && 's'}
-                        </span>
-                      )}
+                      <p className="text-sm text-white font-medium truncate flex-1">
+                        {conn.full_name}
+                      </p>
+                      <div className="flex items-center gap-1.5 shrink-0">
+                        {conn.has_messages && (
+                          <MessageCircle className="h-3.5 w-3.5 text-amber-400" />
+                        )}
+                        {jobMatches.length > 0 && (
+                          <span className="text-[10px] text-emerald-400 bg-emerald-400/10 rounded-full px-1.5 py-0.5 font-medium">
+                            {jobMatches.length} match{jobMatches.length !== 1 && 'es'}
+                          </span>
+                        )}
+                      </div>
                     </div>
                     <div className="flex items-center gap-2 text-xs text-white/50">
-                      {contact.company && (
+                      {conn.company && (
                         <span className="flex items-center gap-1 truncate">
                           <Building2 className="h-3 w-3" />
-                          {contact.company}
+                          {conn.company}
                         </span>
                       )}
-                      {contact.role && <span className="truncate">{contact.role}</span>}
                     </div>
+                    {conn.position && (
+                      <div className="text-xs text-white/40 truncate mt-0.5">
+                        {conn.position}
+                      </div>
+                    )}
                     <div className="mt-1 text-[10px] text-white/30">
-                      {formatDate(contact.created_at)}
-                      {contact.source && ` · ${contact.source}`}
+                      Connected {formatDate(conn.connected_on)}
                     </div>
                   </button>
                 );
@@ -119,39 +175,39 @@ export default function OutreachPage() {
           </div>
         </div>
 
-        {/* Contact Detail */}
-        <div className={`${selectedContact ? 'flex' : 'hidden md:flex'} flex-1 flex-col min-h-0`}>
-          {selectedContact ? (
+        {/* Connection Detail */}
+        <div className={`${selectedConnection ? 'flex' : 'hidden md:flex'} flex-1 flex-col min-h-0`}>
+          {selectedConnection ? (
             <div className="h-full flex flex-col bg-white/5 rounded-lg border border-white/10 p-5 overflow-hidden">
               <button
                 type="button"
-                onClick={() => setSelectedContact(null)}
+                onClick={() => setSelectedConnection(null)}
                 className="md:hidden shrink-0 text-white/60 mb-3 text-sm"
               >
                 &larr; Back
               </button>
 
-              {/* Contact Header */}
+              {/* Connection Header */}
               <div className="shrink-0 border-b border-white/10 pb-4 mb-4">
-                <h2 className="text-lg font-semibold text-white">{selectedContact.name}</h2>
+                <h2 className="text-lg font-semibold text-white">{selectedConnection.full_name}</h2>
                 <div className="flex flex-wrap items-center gap-3 mt-2 text-sm text-white/60">
-                  {selectedContact.company && (
+                  {selectedConnection.company && (
                     <span className="flex items-center gap-1">
                       <Building2 className="h-3.5 w-3.5" />
-                      {selectedContact.company}
+                      {selectedConnection.company}
                     </span>
                   )}
-                  {selectedContact.role && <span>{selectedContact.role}</span>}
+                  {selectedConnection.position && <span>{selectedConnection.position}</span>}
                 </div>
                 <div className="flex flex-wrap gap-2 mt-2">
-                  {selectedContact.email && (
+                  {selectedConnection.email && (
                     <span className="text-xs text-white/50 bg-white/5 rounded px-2 py-1">
-                      {selectedContact.email}
+                      {selectedConnection.email}
                     </span>
                   )}
-                  {selectedContact.linkedin_url && (
+                  {selectedConnection.linkedin_url && (
                     <a
-                      href={selectedContact.linkedin_url}
+                      href={selectedConnection.linkedin_url}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-xs text-blue-400 bg-blue-400/10 rounded px-2 py-1 flex items-center gap-1 hover:bg-blue-400/20"
@@ -159,40 +215,74 @@ export default function OutreachPage() {
                       LinkedIn <ExternalLink className="h-3 w-3" />
                     </a>
                   )}
+                  {selectedConnection.has_messages && (
+                    <span className="text-xs text-amber-400 bg-amber-400/10 rounded px-2 py-1 flex items-center gap-1">
+                      <MessageCircle className="h-3 w-3" /> Has messages
+                    </span>
+                  )}
+                </div>
+                <div className="text-xs text-white/30 mt-2">
+                  Connected {formatDate(selectedConnection.connected_on)}
+                  {selectedConnection.relationship_strength && selectedConnection.relationship_strength !== 'unknown' && (
+                    <> | Relationship: {selectedConnection.relationship_strength}</>
+                  )}
                 </div>
               </div>
 
-              {/* Messages */}
+              {/* Job Matches for this connection */}
               <div className="flex-1 overflow-y-auto space-y-3">
                 <h3 className="text-sm font-medium text-white/60 flex items-center gap-2">
-                  <Send className="h-4 w-4" />
-                  Messages ({contactMessages(selectedContact.id).length})
+                  <Briefcase className="h-4 w-4" />
+                  Job Matches ({connectionMatches(selectedConnection.id).length})
                 </h3>
-                {contactMessages(selectedContact.id).length === 0 ? (
-                  <p className="text-sm text-white/40 py-4">No messages yet</p>
+                {connectionMatches(selectedConnection.id).length === 0 ? (
+                  <p className="text-sm text-white/40 py-4">
+                    No matching jobs found for {selectedConnection.company || 'this company'}
+                  </p>
                 ) : (
-                  contactMessages(selectedContact.id).map((msg) => (
+                  connectionMatches(selectedConnection.id).map((match) => (
                     <div
-                      key={msg.id}
+                      key={match.id}
                       className="bg-white/5 rounded-lg border border-white/10 p-3"
                     >
                       <div className="flex items-center justify-between mb-2">
                         <div className="flex items-center gap-2">
                           <span className={`text-[10px] font-medium rounded-full px-2 py-0.5 ${
-                            statusColors[msg.status] || statusColors.draft
+                            matchTypeColors[match.company_match_type] || 'bg-white/10 text-white/60'
                           }`}>
-                            {msg.status}
+                            {match.company_match_type}
                           </span>
-                          <span className="text-xs text-white/40">{msg.message_type}</span>
+                          <span className="text-xs text-white/40">
+                            {Math.round(match.match_confidence * 100)}% confidence
+                          </span>
                         </div>
-                        <span className="text-xs text-white/30">
-                          {msg.sent_at ? formatDate(msg.sent_at) : formatDate(msg.created_at)}
-                        </span>
+                        {match.job?.match_score && (
+                          <span className={`text-xs font-medium ${
+                            match.job.match_score >= 7 ? 'text-emerald-400' :
+                            match.job.match_score >= 4 ? 'text-amber-400' : 'text-white/40'
+                          }`}>
+                            Score: {match.job.match_score}/10
+                          </span>
+                        )}
                       </div>
-                      {msg.message_text && (
-                        <p className="text-sm text-white/60 whitespace-pre-wrap line-clamp-6">
-                          {msg.message_text}
-                        </p>
+                      {match.job && (
+                        <div>
+                          <p className="text-sm text-white font-medium">{match.job.title}</p>
+                          <p className="text-xs text-white/50 mt-0.5">
+                            {match.job.company}
+                            {match.job.status && (
+                              <span className="ml-2 text-white/30">({match.job.status})</span>
+                            )}
+                          </p>
+                          <a
+                            href={match.job.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300 mt-1"
+                          >
+                            View listing <ExternalLink className="h-3 w-3" />
+                          </a>
+                        </div>
                       )}
                     </div>
                   ))
@@ -201,8 +291,9 @@ export default function OutreachPage() {
             </div>
           ) : (
             <div className="h-full flex flex-col items-center justify-center text-white/40 bg-white/[0.02] rounded-lg border border-white/5">
-              <Users className="h-16 w-16 mb-4 opacity-30" />
-              <p className="text-lg">Select a contact</p>
+              <Link2 className="h-16 w-16 mb-4 opacity-30" />
+              <p className="text-lg">Select a connection</p>
+              <p className="text-sm mt-1">View their details and job matches</p>
             </div>
           )}
         </div>

--- a/app/admin/golem/page.tsx
+++ b/app/admin/golem/page.tsx
@@ -73,8 +73,8 @@ export default function GolemOverview() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-white">Golem Command Center</h1>
-          <p className="text-sm text-white/50 mt-1">Real-time overview of all autonomous agents</p>
+          <h1 className="text-2xl font-bold text-white">Job Search Command Center</h1>
+          <p className="text-sm text-white/50 mt-1">AI-powered job search pipeline</p>
         </div>
         <button
           type="button"
@@ -153,8 +153,8 @@ export default function GolemOverview() {
             <Users className="h-5 w-5 text-amber-400" />
             <ChevronRight className="h-4 w-4 text-white/20 group-hover:text-white/40 transition-colors" />
           </div>
-          <div className="text-2xl font-bold text-white">{stats.totalContacts}</div>
-          <div className="text-xs text-white/50 mt-1">Contacts Found</div>
+          <div className="text-2xl font-bold text-white">{stats.totalConnections}</div>
+          <div className="text-xs text-white/50 mt-1">LinkedIn Connections</div>
         </Link>
       </div>
 


### PR DESCRIPTION
## Summary

- Rebranded admin dashboard from "Golem Command Center" to **Job Search Command Center**
- Added LinkedIn connections server actions with search, pagination, and message filtering
- Rewrote outreach page as a **Connections page** with list/detail layout
- Connection detail panel shows job match data (match type, confidence, score, job listing link)
- Removed "Content" nav (Soltome removed), renamed "Outreach" → "Connections"
- Updated overview stats to show LinkedIn connections count

## Changes

| File | What |
|------|------|
| `layout.tsx` | Nav cleanup: remove Content, rename Outreach → Connections |
| `actions/data.ts` | New `getLinkedInConnections()` + `getConnectionMatches()` server actions, `LinkedInConnection`/`ConnectionMatch` types |
| `page.tsx` | New header, connections stat card |
| `outreach/page.tsx` | Complete rewrite as Connections page with search, filters, detail panel |

## Backend dependency

Requires golems PR #75 (backend tables: `linkedin_connections`, `job_connections`, `golem_jobs`).

## Test plan

- [x] Next.js build passes
- [x] 40 tests pass (vitest)
- [ ] Manual: verify connections list loads from Supabase
- [ ] Manual: verify search and "With Messages" filter work
- [ ] Manual: verify connection detail panel shows job matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it introduces new server actions and Supabase join queries on new tables (`linkedin_connections`, `job_connections`) that can affect performance and runtime behavior if schemas/data differ from expectations.
> 
> **Overview**
> Rebrands the admin overview UI to **Job Search Command Center** and updates navigation by renaming *Outreach* to **Connections** (and removing the unused Content tab).
> 
> Adds Supabase-backed LinkedIn connection support: `getLinkedInConnections` (search, pagination, “has messages” filter) and `getConnectionMatches` (top matches joined to jobs/connections). The `/admin/golem/outreach` page is rewritten into a connections list/detail view that surfaces per-connection job matches (match type, confidence, score, and job link), and the overview stats/card now track and display `totalConnections` from `linkedin_connections`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ec26a9cae828e964b006b06e998573945b68786. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->