### PR TITLE
fix: dashboard UX — action buttons + monitor All tab

### DIFF
--- a/app/admin/golem/components/ActionItem.tsx
+++ b/app/admin/golem/components/ActionItem.tsx
@@ -11,6 +11,8 @@ type ActionItemProps = {
   description: string;
   priority: ActionPriority;
   href?: string;
+  actionLabel?: string;
+  onAction?: () => void;
 };
 
 const priorityStyles: Record<ActionPriority, { container: string; icon: string; badge: string }> = {
@@ -31,7 +33,7 @@ const priorityStyles: Record<ActionPriority, { container: string; icon: string; 
   },
 };
 
-export function ActionItem({ icon, title, description, priority, href }: ActionItemProps) {
+export function ActionItem({ icon, title, description, priority, href, actionLabel, onAction }: ActionItemProps) {
   const styles = priorityStyles[priority];
   const content = (
     <div className={`rounded-xl border p-4 transition-colors hover:bg-white/5 ${styles.container}`}>
@@ -45,6 +47,15 @@ export function ActionItem({ icon, title, description, priority, href }: ActionI
             </span>
           </div>
           <p className="text-xs text-white/60 mt-1">{description}</p>
+          {actionLabel && onAction && (
+            <button
+              type="button"
+              onClick={(e) => { e.preventDefault(); e.stopPropagation(); onAction(); }}
+              className={`mt-2 inline-flex items-center gap-1 rounded-lg border px-3 py-1 text-xs font-medium transition-colors ${styles.badge} hover:bg-white/10`}
+            >
+              {actionLabel}
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/app/admin/golem/monitor/page.tsx
+++ b/app/admin/golem/monitor/page.tsx
@@ -162,10 +162,10 @@ export default function MonitorPage() {
           </div>
 
           <div className="rounded-xl border border-white/10 bg-white/5 p-4 space-y-2">
-            {dashboard.recentEvents.length === 0 ? (
-              <p className="text-sm text-white/50 text-center py-6">No recent events</p>
-            ) : (
-              (actorFilter === 'all' ? dashboard.recentEvents : (actorGroups.get(actorFilter) || [])).map((event) => (
+            {(() => {
+              const events = actorFilter === 'all' ? dashboard.recentEvents : (actorGroups.get(actorFilter) || []);
+              if (events.length === 0) return <p className="text-sm text-white/50 text-center py-6">No recent events</p>;
+              return events.map((event) => (
                 <div key={event.id} className="flex items-start gap-3 text-xs text-white/60">
                   <span className="mt-1 h-1.5 w-1.5 rounded-full bg-white/20" />
                   <div className="flex-1 min-w-0">
@@ -186,7 +186,7 @@ export default function MonitorPage() {
                   </span>
                 </div>
               ))
-            )}
+            })()}
           </div>
         </div>
 

--- a/app/admin/golem/monitor/page.tsx
+++ b/app/admin/golem/monitor/page.tsx
@@ -35,6 +35,7 @@ export default function MonitorPage() {
   const [dashboard, setDashboard] = useState<MonitorDashboard | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [actorFilter, setActorFilter] = useState<string>('all');
 
   const refresh = async () => {
     setLoading(true);
@@ -126,44 +127,65 @@ export default function MonitorPage() {
         {/* Section B: Recent Activity */}
         <div className="space-y-3">
           <h2 className="text-sm font-semibold text-white/80">Recent Activity (48h)</h2>
-          <div className="rounded-xl border border-white/10 bg-white/5 p-4 space-y-4">
+
+          {/* Actor filter tabs */}
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => setActorFilter('all')}
+              className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all ${
+                actorFilter === 'all'
+                  ? 'bg-white/20 text-white'
+                  : 'bg-white/5 text-white/50 hover:bg-white/10'
+              }`}
+            >
+              All ({dashboard.recentEvents.length})
+            </button>
+            {orderedActors.map((actor) => {
+              const count = (actorGroups.get(actor) || []).length;
+              if (count === 0) return null;
+              return (
+                <button
+                  key={actor}
+                  type="button"
+                  onClick={() => setActorFilter(actor)}
+                  className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all ${
+                    actorFilter === actor
+                      ? 'bg-white/20 text-white'
+                      : 'bg-white/5 text-white/50 hover:bg-white/10'
+                  }`}
+                >
+                  {actor} ({count})
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="rounded-xl border border-white/10 bg-white/5 p-4 space-y-2">
             {dashboard.recentEvents.length === 0 ? (
               <p className="text-sm text-white/50 text-center py-6">No recent events</p>
             ) : (
-              orderedActors.map((actor) => {
-                const events = actorGroups.get(actor) || [];
-                if (events.length === 0) return null;
-                return (
-                  <div key={actor} className="space-y-2">
-                    <div className="flex items-center justify-between">
-                      <span className={`text-xs font-semibold uppercase tracking-wider ${actorColors[actor] || 'text-white/60'}`}>
-                        {actor}
+              (actorFilter === 'all' ? dashboard.recentEvents : (actorGroups.get(actorFilter) || [])).map((event) => (
+                <div key={event.id} className="flex items-start gap-3 text-xs text-white/60">
+                  <span className="mt-1 h-1.5 w-1.5 rounded-full bg-white/20" />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className={`font-semibold uppercase tracking-wider text-[10px] ${actorColors[event.actor] || 'text-white/60'}`}>
+                        {event.actor}
                       </span>
-                      <span className="text-xs text-white/40">{events.length} events</span>
-                    </div>
-                    <div className="space-y-2">
-                      {events.map((event) => (
-                        <div key={event.id} className="flex items-start gap-3 text-xs text-white/60">
-                          <span className="mt-1 h-1.5 w-1.5 rounded-full bg-white/20" />
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-center gap-2">
-                              <span className="text-white/70">
-                                {eventTypeLabels[event.type] || event.type}
-                              </span>
-                              <span className="text-white/30">
-                                {getEventDetail(event)}
-                              </span>
-                            </div>
-                          </div>
-                          <span className="text-white/30 whitespace-nowrap">
-                            {formatRelativeTime(event.created_at)}
-                          </span>
-                        </div>
-                      ))}
+                      <span className="text-white/70">
+                        {eventTypeLabels[event.type] || event.type}
+                      </span>
+                      <span className="text-white/30 truncate">
+                        {getEventDetail(event)}
+                      </span>
                     </div>
                   </div>
-                );
-              })
+                  <span className="text-white/30 whitespace-nowrap">
+                    {formatRelativeTime(event.created_at)}
+                  </span>
+                </div>
+              ))
             )}
           </div>
         </div>

--- a/app/admin/golem/recruiter/page.tsx
+++ b/app/admin/golem/recruiter/page.tsx
@@ -115,7 +115,7 @@ export default function RecruiterPage() {
 
   const firstConnection = dashboard.connectionMatches[0];
   const connectionDesc = firstConnection
-    ? `${firstConnection.connectionName} at ${firstConnection.company} — applied to ${firstConnection.jobTitle}${dashboard.connectionMatches.length > 1 ? ` (+${dashboard.connectionMatches.length - 1} more)` : ''}`
+    ? `${firstConnection.connectionName} at ${firstConnection.company || 'their company'} — applied to ${firstConnection.jobTitle || 'a role'}${dashboard.connectionMatches.length > 1 ? ` (+${dashboard.connectionMatches.length - 1} more)` : ''}`
     : 'No connection matches found yet.';
 
   const actionItems = [
@@ -126,7 +126,7 @@ export default function RecruiterPage() {
         : 'No new high-score jobs right now.',
       priority: dashboard.newHighScoreJobs > 0 ? 'urgent' : 'info',
       icon: <Sparkles className="h-4 w-4" />,
-      actionLabel: dashboard.newHighScoreJobs > 0 ? 'Show high-score jobs' : undefined,
+      actionLabel: dashboard.newHighScoreJobs > 0 ? 'Filter to new jobs' : undefined,
       onAction: dashboard.newHighScoreJobs > 0 ? () => setActiveStatus('new') : undefined,
     },
     {
@@ -142,7 +142,7 @@ export default function RecruiterPage() {
     {
       title: `${dashboard.connectionMatches.length} connection matches`,
       description: connectionDesc,
-      priority: dashboard.connectionMatches.length > 0 ? 'info' : 'info',
+      priority: 'info',
       icon: <Users className="h-4 w-4" />,
       actionLabel: dashboard.connectionMatches.length > 0 ? 'View connections' : undefined,
       onAction: dashboard.connectionMatches.length > 0 ? () => setShowConnections(true) : undefined,

--- a/app/admin/golem/recruiter/page.tsx
+++ b/app/admin/golem/recruiter/page.tsx
@@ -113,30 +113,39 @@ export default function RecruiterPage() {
 
   if (!dashboard) return null;
 
+  const firstConnection = dashboard.connectionMatches[0];
+  const connectionDesc = firstConnection
+    ? `${firstConnection.connectionName} at ${firstConnection.company} — applied to ${firstConnection.jobTitle}${dashboard.connectionMatches.length > 1 ? ` (+${dashboard.connectionMatches.length - 1} more)` : ''}`
+    : 'No connection matches found yet.';
+
   const actionItems = [
     {
       title: `Review ${dashboard.newHighScoreJobs} high-score jobs`,
       description: dashboard.newHighScoreJobs > 0
-        ? 'Strong matches are waiting for review.'
+        ? 'New jobs scored 8+ are waiting for review.'
         : 'No new high-score jobs right now.',
       priority: dashboard.newHighScoreJobs > 0 ? 'urgent' : 'info',
       icon: <Sparkles className="h-4 w-4" />,
+      actionLabel: dashboard.newHighScoreJobs > 0 ? 'Show high-score jobs' : undefined,
+      onAction: dashboard.newHighScoreJobs > 0 ? () => setActiveStatus('new') : undefined,
     },
     {
       title: `Follow up on ${dashboard.staleApplications} stale applications`,
       description: dashboard.staleApplications > 0
-        ? 'Applications older than 3 days need attention.'
+        ? 'Applications older than 3 days with no update.'
         : 'No stale applications at the moment.',
       priority: dashboard.staleApplications > 0 ? 'soon' : 'info',
       icon: <Clock className="h-4 w-4" />,
+      actionLabel: dashboard.staleApplications > 0 ? 'Show applied jobs' : undefined,
+      onAction: dashboard.staleApplications > 0 ? () => setActiveStatus('applied') : undefined,
     },
     {
       title: `${dashboard.connectionMatches.length} connection matches`,
-      description: dashboard.connectionMatches.length > 0
-        ? 'Leverage warm intros at applied companies.'
-        : 'No connection matches found yet.',
+      description: connectionDesc,
       priority: dashboard.connectionMatches.length > 0 ? 'info' : 'info',
       icon: <Users className="h-4 w-4" />,
+      actionLabel: dashboard.connectionMatches.length > 0 ? 'View connections' : undefined,
+      onAction: dashboard.connectionMatches.length > 0 ? () => setShowConnections(true) : undefined,
     },
   ];
 
@@ -162,6 +171,8 @@ export default function RecruiterPage() {
                 title={item.title}
                 description={item.description}
                 priority={item.priority as 'urgent' | 'soon' | 'info'}
+                actionLabel={item.actionLabel}
+                onAction={item.onAction}
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- Recruiter: action items now have clickable buttons (filter to high-score, applied, view connections)
- Recruiter: connection matches banner shows actual person name/company
- Monitor: "All" tab as default for recent activity (chronological with actor labels)
- Monitor: per-actor filter tabs with counts

## Test plan
- [x] `next build` passes
- [x] 33 tests pass
- [ ] Visual check on recruiter page (action items have buttons)
- [ ] Visual check on monitor page (All tab, actor filters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes in admin dashboards; main risk is minor UX regressions (filter state/interaction) rather than data/auth logic.
> 
> **Overview**
> Improves admin golem dashboard UX by making `ActionItem` support an optional inline action button (`actionLabel`/`onAction`) and wiring recruiter action items to trigger in-page filters or open the connections section.
> 
> Updates MonitorGolem recent activity to default to an **All** view and adds per-actor filter tabs with counts; the activity list now renders a single chronological feed with actor labels rather than grouped sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15c3f6d1d7d8eb374d8c0fc639df0f8ac947413f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->