### PR TITLE
feat: dashboard critical improvements

### DIFF
--- a/app/admin/golem/actions/data.ts
+++ b/app/admin/golem/actions/data.ts
@@ -675,6 +675,27 @@ export async function correctEmailCategory(
   }
 }
 
+// ─── Job Status Update ───────────────────────────────
+
+export async function updateJobStatus(
+  jobId: string,
+  status: string,
+): Promise<{ success: boolean; error: string | null }> {
+  try {
+    await requireAuth();
+    const validStatuses = ['new', 'viewed', 'saved', 'applied', 'archived'];
+    if (!validStatuses.includes(status)) return { success: false, error: `Invalid status: ${status}` };
+    const supabase = createAdminClient();
+    const updates: Record<string, unknown> = { status, updated_at: new Date().toISOString() };
+    if (status === 'applied') updates.applied_at = new Date().toISOString();
+    const { error } = await supabase.from('golem_jobs').update(updates).eq('id', jobId);
+    if (error) return { success: false, error: error.message };
+    return { success: true, error: null };
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : 'Unknown error' };
+  }
+}
+
 // ─── Job Corrections (Feedback Loop) ────────────────
 
 export async function correctJobRelevance(

--- a/app/admin/golem/monitor/page.tsx
+++ b/app/admin/golem/monitor/page.tsx
@@ -17,7 +17,7 @@ const serviceConfig = [
 ];
 
 function normalizeService(name: string) {
-  return name.toLowerCase().replace(/\s+/g, '-');
+  return name.toLowerCase().replace(/[_\s]+/g, '-');
 }
 
 function getEventDetail(event: MonitorDashboard['recentEvents'][number]): string {


### PR DESCRIPTION
## Summary
- **Recruiter: Job status updates** — dropdown on each job card to change status (new/viewed/saved/applied/archived)
- **Recruiter: High-score filter** — dedicated "Score 8+" toggle button that filters by effective score >= 8
- **Recruiter: Expanded connection matching** — now matches connections for saved/new jobs, not just applied
- **Monitor: Service status from events** — derives status from golem_events when service_runs is empty (fixes 5/6 services showing "unknown")
- **Monitor: Fixed normalizeService** — handles underscores in service names

## Test plan
- [ ] Visit /admin/golem/recruiter — verify status dropdown works on job cards
- [ ] Click "Score 8+" filter — only jobs with score >= 8 shown
- [ ] Click "Show high-score jobs" action card — filters to new + score 8+
- [ ] Visit /admin/golem/monitor — services should show last event time instead of "unknown/never"
- [ ] Connection matches should include saved/new jobs, not just applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new admin write path to update `golem_jobs.status` (and `applied_at`) from the UI, plus changes monitor/overview health derivation to fall back to `golem_events`, which could affect operational visibility if mappings or normalization are wrong.
> 
> **Overview**
> Improves the admin Recruiter dashboard by adding an in-card status dropdown (backed by new server action `updateJobStatus`) and a "Score 8+" toggle that filters by effective score (human override or model score). The "Review high-score jobs" action now drives both the `new` filter and the high-score toggle.
> 
> Expands recruiter connection matching and stale-application calculations by fetching non-applied jobs (`new`/`saved`/`applied`) instead of only `applied`, while keeping stale counts scoped to `applied`.
> 
> Fixes Monitor/Overview service health reporting by normalizing service names to handle underscores and by deriving missing service statuses from recent `golem_events` when `service_runs` data is absent (including updated totals/green counts).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02ce70339d90b7540aba4f38242e822a6df8c3fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->