### PR TITLE
fix: recruiter page regression — modal, checklists, connections

### DIFF
--- a/app/admin/golem/components/ActionItem.tsx
+++ b/app/admin/golem/components/ActionItem.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from 'react';
 import Link from 'next/link';
+import { Check } from 'lucide-react';
 
 type ActionPriority = 'urgent' | 'soon' | 'info';
 
@@ -13,6 +14,8 @@ type ActionItemProps = {
   href?: string;
   actionLabel?: string;
   onAction?: () => void;
+  checked?: boolean;
+  onCheck?: (checked: boolean) => void;
 };
 
 const priorityStyles: Record<ActionPriority, { container: string; icon: string; badge: string }> = {
@@ -33,20 +36,54 @@ const priorityStyles: Record<ActionPriority, { container: string; icon: string; 
   },
 };
 
-export function ActionItem({ icon, title, description, priority, href, actionLabel, onAction }: ActionItemProps) {
+export function ActionItem({
+  icon,
+  title,
+  description,
+  priority,
+  href,
+  actionLabel,
+  onAction,
+  checked = false,
+  onCheck,
+}: ActionItemProps) {
   const styles = priorityStyles[priority];
+  const isChecked = Boolean(checked);
   const content = (
-    <div className={`rounded-xl border p-4 transition-colors hover:bg-white/5 ${styles.container}`}>
+    <div className={`rounded-xl border p-4 transition-colors hover:bg-white/5 ${styles.container} ${isChecked ? 'opacity-60' : ''}`}>
       <div className="flex items-start gap-3">
         <div className={`mt-0.5 ${styles.icon}`}>{icon}</div>
         <div className="flex-1">
           <div className="flex items-center justify-between gap-2">
-            <h3 className="text-sm font-semibold text-white">{title}</h3>
-            <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider ${styles.badge}`}>
-              {priority}
-            </span>
+            <h3 className={`text-sm font-semibold ${isChecked ? 'text-white/60 line-through' : 'text-white'}`}>
+              {title}
+            </h3>
+            <div className="flex items-center gap-2">
+              {onCheck && (
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onCheck(!isChecked);
+                  }}
+                  aria-pressed={isChecked}
+                  aria-label={isChecked ? 'Mark action item as not done' : 'Mark action item as done'}
+                  className={`inline-flex h-6 w-6 items-center justify-center rounded-full border transition-colors ${
+                    isChecked
+                      ? 'border-emerald-500/40 bg-emerald-500/20 text-emerald-300'
+                      : 'border-white/10 text-white/40 hover:bg-white/10'
+                  }`}
+                >
+                  {isChecked && <Check className="h-3.5 w-3.5" />}
+                </button>
+              )}
+              <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider ${styles.badge}`}>
+                {priority}
+              </span>
+            </div>
           </div>
-          <p className="text-xs text-white/60 mt-1">{description}</p>
+          <p className={`text-xs mt-1 ${isChecked ? 'text-white/40' : 'text-white/60'}`}>{description}</p>
           {actionLabel && onAction && (
             <button
               type="button"

--- a/app/admin/golem/recruiter/page.tsx
+++ b/app/admin/golem/recruiter/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Briefcase,
   ExternalLink,
@@ -9,20 +9,18 @@ import {
   Users,
   ChevronDown,
   Loader2,
+  X,
+  Bookmark,
+  Send,
+  Archive,
+  RotateCcw,
+  Check,
 } from 'lucide-react';
 import { getRecruiterDashboard, getRecruiterJobs, type RecruiterDashboard, type RecruiterJob } from '../actions/recruiter';
 import { correctJobScore, updateJobStatus } from '../actions/data';
 import { ActionItem, PageHeader, ScoreEditor } from '../components';
 import { formatRelativeTime } from '../lib/format';
 import { sourceConfig, statusConfig, type JobStatus } from '../lib/constants';
-
-const JOB_STATUS_OPTIONS: { value: JobStatus; label: string }[] = [
-  { value: 'new', label: 'New' },
-  { value: 'viewed', label: 'Viewed' },
-  { value: 'saved', label: 'Saved' },
-  { value: 'applied', label: 'Applied' },
-  { value: 'archived', label: 'Archived' },
-];
 
 function cleanDescription(html: string | null): string {
   if (!html) return '';
@@ -38,14 +36,13 @@ function cleanDescription(html: string | null): string {
     .replace(/&lsquo;/g, "'")
     .replace(/&rdquo;/g, '"')
     .replace(/&ldquo;/g, '"')
-    .replace(/&mdash;/g, '—')
-    .replace(/&ndash;/g, '–');
+    .replace(/&mdash;/g, '\u2014')
+    .replace(/&ndash;/g, '\u2013');
   return text.replace(/\s+/g, ' ').trim();
 }
 
 function isHebrew(text: string): boolean {
-  const hebrewPattern = /[\u0590-\u05FF]/;
-  return hebrewPattern.test(text);
+  return /[\u0590-\u05FF]/.test(text);
 }
 
 function StatusBadge({ status }: { status: string }) {
@@ -63,6 +60,55 @@ function StatusBadge({ status }: { status: string }) {
   );
 }
 
+// --- Action Buttons by Status ---
+function getStatusActions(status: string): Array<{ targetStatus: JobStatus; label: string; icon: typeof Bookmark; color: string }> {
+  switch (status) {
+    case 'new':
+    case 'viewed':
+      return [
+        { targetStatus: 'saved', label: 'Save', icon: Bookmark, color: 'border-amber-500/30 text-amber-400 hover:bg-amber-500/10' },
+        { targetStatus: 'applied', label: 'Applied', icon: Send, color: 'border-emerald-500/30 text-emerald-400 hover:bg-emerald-500/10' },
+        { targetStatus: 'archived', label: 'Not a fit', icon: Archive, color: 'border-zinc-500/30 text-zinc-400 hover:bg-zinc-500/10' },
+      ];
+    case 'saved':
+      return [
+        { targetStatus: 'applied', label: 'Applied', icon: Send, color: 'border-emerald-500/30 text-emerald-400 hover:bg-emerald-500/10' },
+        { targetStatus: 'archived', label: 'Not a fit', icon: Archive, color: 'border-zinc-500/30 text-zinc-400 hover:bg-zinc-500/10' },
+      ];
+    case 'applied':
+      return [
+        { targetStatus: 'archived', label: 'Archive', icon: Archive, color: 'border-zinc-500/30 text-zinc-400 hover:bg-zinc-500/10' },
+      ];
+    case 'archived':
+      return [
+        { targetStatus: 'new', label: 'Restore', icon: RotateCcw, color: 'border-blue-500/30 text-blue-400 hover:bg-blue-500/10' },
+      ];
+    default:
+      return [];
+  }
+}
+
+// --- Dismissed action items (daily reset) ---
+function getDismissedItems(): Set<string> {
+  if (typeof window === 'undefined') return new Set();
+  try {
+    const raw = localStorage.getItem('recruiter-action-items-dismissed');
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    const today = new Date().toISOString().slice(0, 10);
+    if (parsed.date !== today) return new Set();
+    return new Set(parsed.items || []);
+  } catch {
+    return new Set();
+  }
+}
+
+function setDismissedItems(items: Set<string>) {
+  if (typeof window === 'undefined') return;
+  const today = new Date().toISOString().slice(0, 10);
+  localStorage.setItem('recruiter-action-items-dismissed', JSON.stringify({ date: today, items: Array.from(items) }));
+}
+
 export default function RecruiterPage() {
   const [dashboard, setDashboard] = useState<RecruiterDashboard | null>(null);
   const [jobs, setJobs] = useState<RecruiterJob[]>([]);
@@ -70,8 +116,14 @@ export default function RecruiterPage() {
   const [error, setError] = useState<string | null>(null);
   const [activeStatus, setActiveStatus] = useState<JobStatus | 'all'>('all');
   const [highScoreOnly, setHighScoreOnly] = useState(false);
-  const [expandedJobId, setExpandedJobId] = useState<string | null>(null);
+  const [modalJobId, setModalJobId] = useState<string | null>(null);
   const [showConnections, setShowConnections] = useState(false);
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+
+  // Load dismissed state from localStorage on mount
+  useEffect(() => {
+    setDismissed(getDismissedItems());
+  }, []);
 
   const refresh = async () => {
     setLoading(true);
@@ -94,13 +146,50 @@ export default function RecruiterPage() {
     refresh();
   }, []);
 
+  const handleStatusChange = useCallback(async (jobId: string, newStatus: string) => {
+    const { success } = await updateJobStatus(jobId, newStatus);
+    if (success) {
+      setJobs((prev) => prev.map((j) => (j.id === jobId ? { ...j, status: newStatus } : j)));
+    }
+  }, []);
+
+  const openModal = useCallback(async (jobId: string) => {
+    setModalJobId(jobId);
+    // Auto-mark as viewed if currently "new"
+    const job = jobs.find((j) => j.id === jobId);
+    if (job && job.status === 'new') {
+      handleStatusChange(jobId, 'viewed');
+    }
+  }, [jobs, handleStatusChange]);
+
+  const toggleDismiss = useCallback((key: string) => {
+    setDismissed((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      setDismissedItems(next);
+      return next;
+    });
+  }, []);
+
   const statusCounts = dashboard?.jobsByStatus.reduce<Record<string, number>>((acc, item) => {
     acc[item.status] = item.count;
     return acc;
   }, {}) ?? {};
 
+  // "All" excludes applied + archived
+  const activeCount = (dashboard?.totalJobs || 0) - (statusCounts.applied || 0) - (statusCounts.archived || 0);
+
   const filteredJobs = useMemo(() => {
-    let result = activeStatus === 'all' ? jobs : jobs.filter((job) => job.status === activeStatus);
+    let result: RecruiterJob[];
+    if (activeStatus === 'all') {
+      result = jobs.filter((job) => job.status !== 'applied' && job.status !== 'archived');
+    } else {
+      result = jobs.filter((job) => job.status === activeStatus);
+    }
     if (highScoreOnly) {
       result = result.filter((job) => {
         const score = job.human_match_score ?? job.match_score;
@@ -109,6 +198,19 @@ export default function RecruiterPage() {
     }
     return result;
   }, [jobs, activeStatus, highScoreOnly]);
+
+  const modalJob = modalJobId ? jobs.find((j) => j.id === modalJobId) : null;
+
+  // Connections matching the modal job's company
+  const modalConnections = useMemo(() => {
+    if (!modalJob || !dashboard) return [];
+    const jobCompany = (modalJob.company || '').toLowerCase();
+    if (!jobCompany) return [];
+    return dashboard.connectionMatches.filter((conn) => {
+      const connCompany = (conn.company || '').toLowerCase();
+      return connCompany && (connCompany.includes(jobCompany) || jobCompany.includes(connCompany));
+    });
+  }, [modalJob, dashboard]);
 
   if (loading && !dashboard) {
     return (
@@ -130,11 +232,12 @@ export default function RecruiterPage() {
 
   const firstConnection = dashboard.connectionMatches[0];
   const connectionDesc = firstConnection
-    ? `${firstConnection.connectionName} at ${firstConnection.company || 'their company'} — applied to ${firstConnection.jobTitle || 'a role'}${dashboard.connectionMatches.length > 1 ? ` (+${dashboard.connectionMatches.length - 1} more)` : ''}`
+    ? `${firstConnection.connectionName} at ${firstConnection.company || 'their company'}${dashboard.connectionMatches.length > 1 ? ` (+${dashboard.connectionMatches.length - 1} more)` : ''}`
     : 'No connection matches found yet.';
 
   const actionItems = [
     {
+      key: 'high-score',
       title: `Review ${dashboard.newHighScoreJobs} high-score jobs`,
       description: dashboard.newHighScoreJobs > 0
         ? 'New jobs scored 8+ are waiting for review.'
@@ -145,6 +248,7 @@ export default function RecruiterPage() {
       onAction: dashboard.newHighScoreJobs > 0 ? () => { setActiveStatus('new'); setHighScoreOnly(true); } : undefined,
     },
     {
+      key: 'stale-apps',
       title: `Follow up on ${dashboard.staleApplications} stale applications`,
       description: dashboard.staleApplications > 0
         ? 'Applications older than 3 days with no update.'
@@ -155,9 +259,10 @@ export default function RecruiterPage() {
       onAction: dashboard.staleApplications > 0 ? () => setActiveStatus('applied') : undefined,
     },
     {
+      key: 'connections',
       title: `${dashboard.connectionMatches.length} connection matches`,
       description: connectionDesc,
-      priority: 'info',
+      priority: 'info' as const,
       icon: <Users className="h-4 w-4" />,
       actionLabel: dashboard.connectionMatches.length > 0 ? 'View connections' : undefined,
       onAction: dashboard.connectionMatches.length > 0 ? () => setShowConnections(true) : undefined,
@@ -175,19 +280,21 @@ export default function RecruiterPage() {
       />
 
       <div className="flex-1 overflow-y-auto space-y-6 pb-8">
-        {/* Section A: Action Items */}
+        {/* Section A: Action Items (checkable) */}
         <div className="space-y-3">
           <h2 className="text-sm font-semibold text-white/80">Action Items</h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
             {actionItems.map((item) => (
               <ActionItem
-                key={item.title}
+                key={item.key}
                 icon={item.icon}
                 title={item.title}
                 description={item.description}
                 priority={item.priority as 'urgent' | 'soon' | 'info'}
                 actionLabel={item.actionLabel}
                 onAction={item.onAction}
+                checked={dismissed.has(item.key)}
+                onCheck={() => toggleDismiss(item.key)}
               />
             ))}
           </div>
@@ -198,7 +305,7 @@ export default function RecruiterPage() {
           <h2 className="text-sm font-semibold text-white/80">Jobs Pipeline</h2>
           <div className="flex flex-wrap items-center gap-2">
             {([
-              { key: 'all', label: 'All', count: dashboard.totalJobs },
+              { key: 'all', label: 'All', count: activeCount },
               { key: 'new', label: 'New', count: statusCounts.new || 0 },
               { key: 'viewed', label: 'Viewed', count: statusCounts.viewed || 0 },
               { key: 'saved', label: 'Saved', count: statusCounts.saved || 0 },
@@ -247,95 +354,34 @@ export default function RecruiterPage() {
                 const source = sourceConfig[job.source] || { label: job.source, color: 'text-white/60' };
                 const effectiveScore = job.human_match_score ?? job.match_score;
                 const cleanedDescription = cleanDescription(job.description);
-                const isExpanded = expandedJobId === job.id;
-                const descIsHebrew = isHebrew(cleanedDescription);
 
                 return (
-                  <div
+                  <button
                     key={job.id}
-                    className={`rounded-lg border border-white/10 bg-white/5 p-4 border-l-4 ${statusStyle.cardBorder}`}
+                    type="button"
+                    onClick={() => openModal(job.id)}
+                    className={`w-full text-left rounded-lg border border-white/10 bg-white/5 p-4 border-l-4 ${statusStyle.cardBorder} hover:bg-white/8 transition-colors cursor-pointer`}
                   >
                     <div className="flex items-start justify-between gap-3 mb-2">
                       <div>
                         <h3 className="text-sm font-semibold text-white">{job.title}</h3>
                         <p className="text-xs text-white/60">{job.company}</p>
                       </div>
-                      <select
-                        value={job.status}
-                        onChange={async (e) => {
-                          const newStatus = e.target.value;
-                          const { success } = await updateJobStatus(job.id, newStatus);
-                          if (success) {
-                            setJobs((prev) => prev.map((j) => (j.id === job.id ? { ...j, status: newStatus } : j)));
-                          }
-                        }}
-                        className="text-xs rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-white/70 focus:outline-none focus:ring-1 focus:ring-white/20"
-                      >
-                        {JOB_STATUS_OPTIONS.map((opt) => (
-                          <option key={opt.value} value={opt.value} className="bg-[#00003f] text-white">
-                            {opt.label}
-                          </option>
-                        ))}
-                      </select>
+                      <StatusBadge status={job.status} />
                     </div>
                     <div className="flex flex-wrap items-center gap-3 text-xs text-white/50 mb-2">
                       <span className={source.color}>{source.label}</span>
                       <span>{formatRelativeTime(job.scraped_at)}</span>
-                      <ScoreEditor
-                        value={effectiveScore}
-                        label="Match"
-                        hasCorrected={job.human_match_score !== null}
-                        onSave={async (score) => {
-                          const { success } = await correctJobScore(job.id, score);
-                          if (success) {
-                            setJobs((prev) => prev.map((j) => (j.id === job.id ? { ...j, human_match_score: score } : j)));
-                          }
-                        }}
-                      />
-                      <a
-                        href={job.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300"
-                      >
-                        <ExternalLink className="h-3 w-3" />
-                        View
-                      </a>
+                      {effectiveScore !== null && (
+                        <span className={effectiveScore >= 8 ? 'text-red-400 font-semibold' : effectiveScore >= 6 ? 'text-amber-400' : 'text-white/40'}>
+                          Score: {effectiveScore}
+                        </span>
+                      )}
                     </div>
                     {cleanedDescription && (
                       <p className="text-xs text-white/40 line-clamp-2">{cleanedDescription}</p>
                     )}
-                    <button
-                      type="button"
-                      onClick={() => setExpandedJobId(isExpanded ? null : job.id)}
-                      className="mt-2 flex items-center gap-1 text-xs text-white/50 hover:text-white/70"
-                    >
-                      <ChevronDown className={`h-3 w-3 transition-transform ${isExpanded ? 'rotate-180' : ''}`} />
-                      {isExpanded ? 'Hide details' : 'Show details'}
-                    </button>
-                    {isExpanded && (
-                      <div className="mt-3 space-y-3 text-xs text-white/60">
-                        <div className="border-t border-white/10 pt-3">
-                          <p className="text-white/70 mb-1">Description</p>
-                          <p dir={descIsHebrew ? 'rtl' : 'ltr'}>
-                            {cleanedDescription || 'No description provided.'}
-                          </p>
-                        </div>
-                        <div>
-                          <p className="text-white/70 mb-1">Match Reasons</p>
-                          {job.match_reasons && job.match_reasons.length > 0 ? (
-                            <ul className="list-disc list-inside space-y-1">
-                              {job.match_reasons.map((reason) => (
-                                <li key={reason}>{reason}</li>
-                              ))}
-                            </ul>
-                          ) : (
-                            <p className="text-white/40">No match reasons provided.</p>
-                          )}
-                        </div>
-                      </div>
-                    )}
-                  </div>
+                  </button>
                 );
               })
             )}
@@ -349,7 +395,7 @@ export default function RecruiterPage() {
             onClick={() => setShowConnections((prev) => !prev)}
             className="w-full flex items-center justify-between text-sm font-semibold text-white/80"
           >
-            Network Matches
+            Network Matches ({dashboard.connectionMatches.length})
             <ChevronDown className={`h-4 w-4 transition-transform ${showConnections ? 'rotate-180' : ''}`} />
           </button>
           {showConnections && (
@@ -358,23 +404,25 @@ export default function RecruiterPage() {
                 <p className="text-xs text-white/50">No connection matches yet.</p>
               ) : (
                 dashboard.connectionMatches.map((match, index) => (
-                  <div key={`${match.connectionName}-${index}`} className="flex items-center justify-between gap-3 rounded-lg border border-white/10 bg-white/5 p-3">
-                    <div>
-                      <p className="text-sm text-white">{match.connectionName}</p>
-                      <p className="text-xs text-white/50">
-                        {match.position || 'Unknown role'} · {match.company || 'Unknown company'}
-                      </p>
-                      <p className="text-xs text-white/40 mt-1">
-                        Applied: {match.jobTitle} at {match.jobCompany}
-                      </p>
+                  <div key={`${match.connectionName}-${index}`} className="rounded-lg border border-white/10 bg-white/5 p-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm text-white">{match.connectionName}</p>
+                        <p className="text-xs text-white/50">
+                          {match.position || 'Unknown role'} · {match.company || 'Unknown company'}
+                        </p>
+                      </div>
                     </div>
-                    <button
-                      type="button"
-                      className="text-xs font-medium rounded-lg border border-white/10 px-3 py-1.5 text-white/60 hover:bg-white/5"
-                      disabled
-                    >
-                      Draft message
-                    </button>
+                    {match.matchingJobs.length > 0 && (
+                      <div className="mt-2 space-y-1">
+                        {match.matchingJobs.map((mj, i) => (
+                          <p key={i} className="text-xs text-white/40 flex items-center gap-1">
+                            <StatusBadge status={mj.status} />
+                            <span>{mj.title} at {mj.company}</span>
+                          </p>
+                        ))}
+                      </div>
+                    )}
                   </div>
                 ))
               )}
@@ -382,6 +430,132 @@ export default function RecruiterPage() {
           )}
         </div>
       </div>
+
+      {/* Job Detail Modal */}
+      {modalJob && (() => {
+        const cleanedDescription = cleanDescription(modalJob.description);
+        const descIsHebrew = isHebrew(cleanedDescription);
+        const effectiveScore = modalJob.human_match_score ?? modalJob.match_score;
+        const source = sourceConfig[modalJob.source] || { label: modalJob.source, color: 'text-white/60' };
+        const actions = getStatusActions(modalJob.status);
+
+        return (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+            onClick={(e) => { if (e.target === e.currentTarget) setModalJobId(null); }}
+          >
+            <div className="relative w-full max-w-2xl max-h-[85vh] overflow-y-auto rounded-xl border border-white/10 bg-[#00003f] p-6 shadow-2xl">
+              {/* Close button */}
+              <button
+                type="button"
+                onClick={() => setModalJobId(null)}
+                className="absolute top-4 right-4 text-white/40 hover:text-white/70"
+              >
+                <X className="h-5 w-5" />
+              </button>
+
+              {/* Header */}
+              <div className="mb-4">
+                <h2 className="text-lg font-bold text-white pr-8">{modalJob.title}</h2>
+                <p className="text-sm text-white/60">{modalJob.company}</p>
+                <div className="flex flex-wrap items-center gap-3 mt-2 text-xs text-white/50">
+                  <StatusBadge status={modalJob.status} />
+                  <span className={source.color}>{source.label}</span>
+                  <span>{formatRelativeTime(modalJob.scraped_at)}</span>
+                  <a
+                    href={modalJob.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <ExternalLink className="h-3 w-3" />
+                    Open listing
+                  </a>
+                </div>
+              </div>
+
+              {/* Action Buttons */}
+              <div className="flex flex-wrap items-center gap-2 mb-4">
+                {actions.map((action) => {
+                  const Icon = action.icon;
+                  return (
+                    <button
+                      key={action.targetStatus}
+                      type="button"
+                      onClick={async () => {
+                        await handleStatusChange(modalJob.id, action.targetStatus);
+                        if (action.targetStatus === 'archived') {
+                          setModalJobId(null);
+                        }
+                      }}
+                      className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${action.color}`}
+                    >
+                      <Icon className="h-3 w-3" />
+                      {action.label}
+                    </button>
+                  );
+                })}
+                <div className="ml-auto">
+                  <ScoreEditor
+                    value={effectiveScore}
+                    label="Match"
+                    hasCorrected={modalJob.human_match_score !== null}
+                    onSave={async (score) => {
+                      const { success } = await correctJobScore(modalJob.id, score);
+                      if (success) {
+                        setJobs((prev) => prev.map((j) => (j.id === modalJob.id ? { ...j, human_match_score: score } : j)));
+                      }
+                    }}
+                  />
+                </div>
+              </div>
+
+              {/* Description */}
+              {cleanedDescription && (
+                <div className="mb-4">
+                  <h3 className="text-xs font-semibold text-white/70 mb-2">Description</h3>
+                  <p className="text-xs text-white/60 leading-relaxed" dir={descIsHebrew ? 'rtl' : 'ltr'}>
+                    {cleanedDescription}
+                  </p>
+                </div>
+              )}
+
+              {/* Match Reasons */}
+              {modalJob.match_reasons && modalJob.match_reasons.length > 0 && (
+                <div className="mb-4">
+                  <h3 className="text-xs font-semibold text-white/70 mb-2">Match Reasons</h3>
+                  <ul className="list-disc list-inside space-y-1 text-xs text-white/60">
+                    {modalJob.match_reasons.map((reason) => (
+                      <li key={reason}>{reason}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {/* Connections at this company */}
+              {modalConnections.length > 0 && (
+                <div className="border-t border-white/10 pt-4">
+                  <h3 className="text-xs font-semibold text-white/70 mb-2">
+                    <Users className="h-3 w-3 inline mr-1" />
+                    Connections at {modalJob.company} ({modalConnections.length})
+                  </h3>
+                  <div className="space-y-2">
+                    {modalConnections.map((conn, i) => (
+                      <div key={i} className="rounded-lg border border-white/10 bg-white/5 p-2">
+                        <p className="text-sm text-white">{conn.connectionName}</p>
+                        <p className="text-xs text-white/50">
+                          {conn.position || 'Unknown role'} · {conn.company || 'Unknown company'}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      })()}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Major recruiter page overhaul addressing user feedback:

- **"All" tab excludes applied/archived** — shows only active pipeline jobs
- **Job detail modal** — clicking a job opens a proper modal instead of inline expand
- **Action buttons** — Save/Apply/Archive/Restore buttons replace the select dropdown
- **Auto-viewed** — jobs automatically marked as "viewed" when clicked
- **Deduplicated connections** — grouped by person, shows all matching jobs per connection
- **Modal connections** — shows connections at the specific job's company in the modal
- **Checkable action items** — can be marked as done, resets daily via localStorage

## Test plan
- [x] Build passes
- [x] 33 tests pass
- [ ] Visual: open recruiter page, verify "All" excludes applied/archived
- [ ] Visual: click job → modal opens, auto-marks as viewed
- [ ] Visual: use Save/Apply/Archive buttons in modal
- [ ] Visual: check action items show checkmark, reset next day
- [ ] Visual: connections section shows unique people with matching jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to a significant UI interaction refactor (modal flow, status transitions) and a `RecruiterDashboard.connectionMatches` response shape change that could break any other consumers.
> 
> **Overview**
> Refactors the recruiter jobs pipeline UX: the **"All" tab now shows only active jobs** (excludes `applied`/`archived`), job cards open a **detail modal** (replacing inline expansion), and jobs are auto-marked `viewed` on open with status changes driven by contextual action buttons (Save/Applied/Archive/Restore).
> 
> Makes action items **checkable/dismissible** with a daily reset persisted in `localStorage`, and updates `ActionItem` to support a checked state.
> 
> Improves network matching by changing `connectionMatches` to **dedupe connections and group all matching jobs per person** (new `matchingJobs` array), and surfaces connections relevant to the currently viewed job inside the modal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dad1fcaff50c15bcc42c3d9cb69522f573ceeb6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->