### PR TITLE
feat: add header navbar to golems docsite

### DIFF
--- a/app/(golems)/golems/components/Header.tsx
+++ b/app/(golems)/golems/components/Header.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import Link from 'next/link';
+import Image from 'next/image';
+import { usePathname } from 'next/navigation';
+import { useState } from 'react';
+import { Menu, X } from 'lucide-react';
+
+const navLinks = [
+  { label: 'Docs', href: '/golems/docs/getting-started' },
+  { label: 'Journey', href: '/golems/docs/journey' },
+  { label: 'For LLMs', href: '/golems/docs/llm' },
+];
+
+const externalLinks = [
+  { label: 'etanheyman.com', href: 'https://etanheyman.com' },
+  { label: 'GitHub', href: 'https://github.com/EtanHey/golems' },
+];
+
+export default function Header() {
+  const pathname = usePathname();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <header className="sticky top-0 z-50 bg-[#0c0b0a]/95 backdrop-blur-sm border-b border-[#e5950015]">
+      <div className="flex items-center justify-between px-4 h-12 max-w-[1400px] mx-auto">
+        {/* Left: Logo + nav links */}
+        <div className="flex items-center gap-6">
+          <Link
+            href="/golems"
+            className="flex items-center gap-2 shrink-0"
+          >
+            <Image
+              src="/images/golems-logo.svg"
+              alt="Golems"
+              width={24}
+              height={24}
+              className="drop-shadow-[0_0_8px_rgba(229,149,0,0.3)]"
+            />
+            <span className="font-bold text-[#e59500] text-sm tracking-tight">Golems</span>
+          </Link>
+
+          <nav className="hidden md:flex items-center gap-1">
+            {navLinks.map((link) => {
+              const isActive = pathname.startsWith(link.href);
+              return (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className={`px-3 py-1.5 rounded-md text-sm transition-colors ${
+                    isActive
+                      ? 'text-[#e59500] bg-[#e5950015]'
+                      : 'text-[#908575] hover:text-[#c0b8a8] hover:bg-[#ffffff08]'
+                  }`}
+                >
+                  {link.label}
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
+
+        {/* Right: external links (desktop) + hamburger (mobile) */}
+        <div className="flex items-center gap-3">
+          <nav className="hidden md:flex items-center gap-3">
+            {externalLinks.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#7c6f5e] hover:text-[#c0b8a8] text-sm transition-colors"
+              >
+                {link.label}
+              </a>
+            ))}
+          </nav>
+
+          <button
+            type="button"
+            onClick={() => setMobileOpen(!mobileOpen)}
+            className="md:hidden text-[#e59500] p-1"
+            aria-label="Toggle navigation"
+          >
+            {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+          </button>
+        </div>
+      </div>
+
+      {/* Mobile dropdown */}
+      {mobileOpen && (
+        <nav className="md:hidden border-t border-[#e5950015] bg-[#0c0b0a] px-4 py-3 space-y-1">
+          {navLinks.map((link) => {
+            const isActive = pathname.startsWith(link.href);
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                onClick={() => setMobileOpen(false)}
+                className={`block px-3 py-2 rounded-md text-sm transition-colors ${
+                  isActive
+                    ? 'text-[#e59500] bg-[#e5950015]'
+                    : 'text-[#908575] hover:text-[#c0b8a8] hover:bg-[#ffffff08]'
+                }`}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
+          <div className="border-t border-[#e5950015] pt-2 mt-2 space-y-1">
+            {externalLinks.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => setMobileOpen(false)}
+                className="block px-3 py-2 rounded-md text-sm text-[#7c6f5e] hover:text-[#c0b8a8] hover:bg-[#ffffff08] transition-colors"
+              >
+                {link.label} &rarr;
+              </a>
+            ))}
+          </div>
+        </nav>
+      )}
+    </header>
+  );
+}

--- a/app/(golems)/golems/components/Header.tsx
+++ b/app/(golems)/golems/components/Header.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import { useState } from 'react';
-import { Menu, X } from 'lucide-react';
+import { Menu, X, ChevronDown } from 'lucide-react';
 
 const navLinks = [
   { label: 'Docs', href: '/golems/docs/getting-started' },
@@ -17,37 +17,138 @@ const externalLinks = [
   { label: 'GitHub', href: 'https://github.com/EtanHey/golems' },
 ];
 
+const docsSections = [
+  {
+    title: 'Overview',
+    items: [
+      { title: 'Getting Started', href: '/golems/docs/getting-started' },
+      { title: 'Architecture', href: '/golems/docs/architecture' },
+    ],
+  },
+  {
+    title: 'Golems',
+    items: [
+      { title: 'EmailGolem', href: '/golems/docs/golems/email' },
+      { title: 'RecruiterGolem', href: '/golems/docs/golems/recruiter' },
+      { title: 'ClaudeGolem', href: '/golems/docs/golems/claude' },
+      { title: 'TellerGolem', href: '/golems/docs/golems/teller' },
+      { title: 'JobGolem', href: '/golems/docs/golems/job-golem' },
+    ],
+  },
+  {
+    title: 'Infrastructure',
+    items: [
+      { title: 'Cloud Worker', href: '/golems/docs/cloud-worker' },
+      { title: 'MCP Tools', href: '/golems/docs/mcp-tools' },
+      { title: 'LLM Integration', href: '/golems/docs/llm' },
+      { title: 'Per-Repo Sessions', href: '/golems/docs/per-repo-sessions' },
+    ],
+  },
+  {
+    title: 'Configuration',
+    items: [
+      { title: 'Environment Variables', href: '/golems/docs/configuration/env-vars' },
+      { title: 'Secrets', href: '/golems/docs/configuration/secrets' },
+    ],
+  },
+  {
+    title: 'Deployment',
+    items: [
+      { title: 'Railway', href: '/golems/docs/deployment/railway' },
+    ],
+  },
+  {
+    title: 'More',
+    items: [
+      { title: 'Engineering Journey', href: '/golems/docs/journey' },
+    ],
+  },
+];
+
 export default function Header() {
   const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [docsExpanded, setDocsExpanded] = useState(false);
+  const isDocsPage = pathname.startsWith('/golems/docs');
 
   return (
-    <header className="sticky top-0 z-50 bg-[#0c0b0a]/95 backdrop-blur-sm border-b border-[#e5950015]">
-      <div className="flex items-center justify-between px-4 h-12 max-w-[1400px] mx-auto">
-        {/* Left: Logo + nav links */}
-        <div className="flex items-center gap-6">
-          <Link
-            href="/golems"
-            className="flex items-center gap-2 shrink-0"
-          >
-            <Image
-              src="/images/golems-logo.svg"
-              alt="Golems"
-              width={24}
-              height={24}
-              className="drop-shadow-[0_0_8px_rgba(229,149,0,0.3)]"
-            />
-            <span className="font-bold text-[#e59500] text-sm tracking-tight">Golems</span>
-          </Link>
+    <>
+      <header className="sticky top-0 z-50 bg-[#0c0b0a]/95 backdrop-blur-sm border-b border-[#e5950015]">
+        <div className="flex items-center justify-between px-4 h-12 max-w-[1400px] mx-auto">
+          {/* Left: Logo + nav links */}
+          <div className="flex items-center gap-6">
+            <Link
+              href="/golems"
+              className="flex items-center gap-2 shrink-0"
+            >
+              <Image
+                src="/images/golems-logo.svg"
+                alt="Golems"
+                width={24}
+                height={24}
+                className="drop-shadow-[0_0_8px_rgba(229,149,0,0.3)]"
+              />
+              <span className="font-bold text-[#e59500] text-sm tracking-tight">Golems</span>
+            </Link>
 
-          <nav className="hidden md:flex items-center gap-1">
+            <nav className="hidden md:flex items-center gap-1">
+              {navLinks.map((link) => {
+                const isActive = pathname.startsWith(link.href);
+                return (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    className={`px-3 py-1.5 rounded-md text-sm transition-colors ${
+                      isActive
+                        ? 'text-[#e59500] bg-[#e5950015]'
+                        : 'text-[#908575] hover:text-[#c0b8a8] hover:bg-[#ffffff08]'
+                    }`}
+                  >
+                    {link.label}
+                  </Link>
+                );
+              })}
+            </nav>
+          </div>
+
+          {/* Right: external links (desktop) + hamburger (mobile) */}
+          <div className="flex items-center gap-3">
+            <nav className="hidden md:flex items-center gap-3">
+              {externalLinks.map((link) => (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[#7c6f5e] hover:text-[#c0b8a8] text-sm transition-colors"
+                >
+                  {link.label}
+                </a>
+              ))}
+            </nav>
+
+            <button
+              type="button"
+              onClick={() => { setMobileOpen(!mobileOpen); setDocsExpanded(false); }}
+              className="md:hidden text-[#e59500] p-1"
+              aria-label="Toggle navigation"
+            >
+              {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+            </button>
+          </div>
+        </div>
+
+        {/* Mobile dropdown */}
+        {mobileOpen && (
+          <nav className="md:hidden border-t border-[#e5950015] bg-[#0c0b0a] px-4 py-3 space-y-1 max-h-[calc(100vh-3rem)] overflow-y-auto">
             {navLinks.map((link) => {
               const isActive = pathname.startsWith(link.href);
               return (
                 <Link
                   key={link.href}
                   href={link.href}
-                  className={`px-3 py-1.5 rounded-md text-sm transition-colors ${
+                  onClick={() => setMobileOpen(false)}
+                  className={`block px-3 py-2 rounded-md text-sm transition-colors ${
                     isActive
                       ? 'text-[#e59500] bg-[#e5950015]'
                       : 'text-[#908575] hover:text-[#c0b8a8] hover:bg-[#ffffff08]'
@@ -57,72 +158,78 @@ export default function Header() {
                 </Link>
               );
             })}
+
+            {/* Docs navigation (expandable on mobile) */}
+            {isDocsPage && (
+              <>
+                <button
+                  type="button"
+                  onClick={() => setDocsExpanded(!docsExpanded)}
+                  className="flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm text-[#e59500] hover:bg-[#e5950015] transition-colors mt-2"
+                >
+                  <ChevronDown className={`h-4 w-4 transition-transform ${docsExpanded ? 'rotate-180' : ''}`} />
+                  Doc Pages
+                </button>
+                {docsExpanded && (
+                  <div className="pl-2 space-y-3 pt-1">
+                    {docsSections.map((section) => (
+                      <div key={section.title}>
+                        <h4 className="text-[10px] font-bold uppercase tracking-widest text-[#7c6f5e] mb-1 px-3">
+                          {section.title}
+                        </h4>
+                        {section.items.map((item) => {
+                          const isActive = pathname === item.href;
+                          return (
+                            <Link
+                              key={item.href}
+                              href={item.href}
+                              onClick={() => setMobileOpen(false)}
+                              className={`block px-3 py-1.5 rounded-md text-sm transition-colors ${
+                                isActive
+                                  ? 'bg-[#e5950015] text-[#e59500] font-medium'
+                                  : 'text-[#908575] hover:text-[#c0b8a8] hover:bg-[#ffffff08]'
+                              }`}
+                            >
+                              {item.title}
+                            </Link>
+                          );
+                        })}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+
+            <div className="border-t border-[#e5950015] pt-2 mt-2 space-y-1">
+              {externalLinks.map((link) => (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => setMobileOpen(false)}
+                  className="block px-3 py-2 rounded-md text-sm text-[#7c6f5e] hover:text-[#c0b8a8] hover:bg-[#ffffff08] transition-colors"
+                >
+                  {link.label} &rarr;
+                </a>
+              ))}
+            </div>
           </nav>
-        </div>
+        )}
+      </header>
 
-        {/* Right: external links (desktop) + hamburger (mobile) */}
-        <div className="flex items-center gap-3">
-          <nav className="hidden md:flex items-center gap-3">
-            {externalLinks.map((link) => (
-              <a
-                key={link.href}
-                href={link.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-[#7c6f5e] hover:text-[#c0b8a8] text-sm transition-colors"
-              >
-                {link.label}
-              </a>
-            ))}
-          </nav>
-
-          <button
-            type="button"
-            onClick={() => setMobileOpen(!mobileOpen)}
-            className="md:hidden text-[#e59500] p-1"
-            aria-label="Toggle navigation"
-          >
-            {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
-          </button>
-        </div>
-      </div>
-
-      {/* Mobile dropdown */}
+      {/* Mobile overlay to close menu */}
       {mobileOpen && (
-        <nav className="md:hidden border-t border-[#e5950015] bg-[#0c0b0a] px-4 py-3 space-y-1">
-          {navLinks.map((link) => {
-            const isActive = pathname.startsWith(link.href);
-            return (
-              <Link
-                key={link.href}
-                href={link.href}
-                onClick={() => setMobileOpen(false)}
-                className={`block px-3 py-2 rounded-md text-sm transition-colors ${
-                  isActive
-                    ? 'text-[#e59500] bg-[#e5950015]'
-                    : 'text-[#908575] hover:text-[#c0b8a8] hover:bg-[#ffffff08]'
-                }`}
-              >
-                {link.label}
-              </Link>
-            );
-          })}
-          <div className="border-t border-[#e5950015] pt-2 mt-2 space-y-1">
-            {externalLinks.map((link) => (
-              <a
-                key={link.href}
-                href={link.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => setMobileOpen(false)}
-                className="block px-3 py-2 rounded-md text-sm text-[#7c6f5e] hover:text-[#c0b8a8] hover:bg-[#ffffff08] transition-colors"
-              >
-                {link.label} &rarr;
-              </a>
-            ))}
-          </div>
-        </nav>
+        <div
+          className="fixed inset-0 z-40 md:hidden"
+          role="button"
+          tabIndex={0}
+          aria-label="Close navigation"
+          onClick={() => setMobileOpen(false)}
+          onKeyDown={(e) => { if (e.key === 'Escape') setMobileOpen(false); }}
+        />
       )}
-    </header>
+    </>
   );
 }

--- a/app/(golems)/golems/components/Sidebar.tsx
+++ b/app/(golems)/golems/components/Sidebar.tsx
@@ -1,10 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import Image from 'next/image';
 import { usePathname } from 'next/navigation';
-import { useState } from 'react';
-import { Menu, X, ArrowLeft } from 'lucide-react';
 
 interface SidebarItem {
   title: string;
@@ -66,109 +63,44 @@ const sidebarConfig: SidebarSection[] = [
 
 export default function Sidebar() {
   const pathname = usePathname();
-  const [mobileOpen, setMobileOpen] = useState(false);
 
   const isDocsPage = pathname.startsWith('/golems/docs');
 
-  const sidebarNav = (
-    <nav className="flex flex-col gap-6 p-4">
-      <Link
-        href="/"
-        className="flex items-center gap-2 text-xs text-[#7c6f5e] hover:text-[#c0b8a8] transition-colors mb-2"
-      >
-        <ArrowLeft className="h-3 w-3" />
-        etanheyman.com
-      </Link>
-
-      <Link
-        href="/golems"
-        onClick={() => setMobileOpen(false)}
-        className="text-[#e59500] font-bold text-lg tracking-tight hover:text-[#f0ebe0] transition-colors"
-      >
-        Golems
-      </Link>
-
-      {sidebarConfig.map((section) => (
-        <div key={section.title}>
-          <h3 className="text-[10px] font-bold uppercase tracking-widest text-[#7c6f5e] mb-2">
-            {section.title}
-          </h3>
-          <ul className="space-y-0.5">
-            {section.items.map((item) => {
-              const isActive = pathname === item.href;
-              return (
-                <li key={item.href}>
-                  <Link
-                    href={item.href}
-                    onClick={() => setMobileOpen(false)}
-                    className={`block px-3 py-1.5 rounded-md text-sm transition-colors ${
-                      isActive
-                        ? 'bg-[#e5950015] text-[#e59500] font-medium'
-                        : 'text-[#908575] hover:text-[#c0b8a8] hover:bg-[#ffffff08]'
-                    }`}
-                  >
-                    {item.title}
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      ))}
-    </nav>
-  );
+  // Only show sidebar on doc pages
+  if (!isDocsPage) return null;
 
   return (
-    <>
-      {/* Mobile header bar — visible on doc pages below md */}
-      {isDocsPage && (
-        <header className="fixed top-0 left-0 right-0 z-50 md:hidden bg-[#0c0b0a]/95 backdrop-blur-sm border-b border-[#e5950015]">
-          <div className="flex items-center gap-3 px-4 h-12">
-            <button
-              type="button"
-              onClick={() => setMobileOpen(!mobileOpen)}
-              className="text-[#e59500] p-1 -ml-1"
-              aria-label="Toggle navigation"
-            >
-              {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
-            </button>
-            <Link href="/golems" onClick={() => setMobileOpen(false)} className="flex items-center gap-2">
-              <Image
-                src="/images/golems-logo.svg"
-                alt="Golems"
-                width={24}
-                height={24}
-                className="shrink-0 drop-shadow-[0_0_8px_rgba(229,149,0,0.3)]"
-              />
-              <span className="font-bold text-[#e59500] text-sm tracking-tight">Golems</span>
-            </Link>
+    <aside
+      className="hidden md:block w-64 shrink-0 sticky top-12 h-[calc(100vh-3rem)] overflow-y-auto scrollbar-none bg-[#0c0b0a] border-r border-[#e5950015]"
+    >
+      <nav className="flex flex-col gap-6 p-4">
+        {sidebarConfig.map((section) => (
+          <div key={section.title}>
+            <h3 className="text-[10px] font-bold uppercase tracking-widest text-[#7c6f5e] mb-2">
+              {section.title}
+            </h3>
+            <ul className="space-y-0.5">
+              {section.items.map((item) => {
+                const isActive = pathname === item.href;
+                return (
+                  <li key={item.href}>
+                    <Link
+                      href={item.href}
+                      className={`block px-3 py-1.5 rounded-md text-sm transition-colors ${
+                        isActive
+                          ? 'bg-[#e5950015] text-[#e59500] font-medium'
+                          : 'text-[#908575] hover:text-[#c0b8a8] hover:bg-[#ffffff08]'
+                      }`}
+                    >
+                      {item.title}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
           </div>
-        </header>
-      )}
-
-      {/* Mobile overlay */}
-      {mobileOpen && (
-        <div
-          className="fixed inset-0 bg-black/60 z-40 md:hidden"
-          role="button"
-          tabIndex={0}
-          aria-label="Close navigation"
-          onClick={() => setMobileOpen(false)}
-          onKeyDown={(e) => { if (e.key === 'Escape' || e.key === 'Enter') setMobileOpen(false); }}
-        />
-      )}
-
-      {/* Sidebar */}
-      <aside
-        className={`fixed top-0 left-0 h-full w-64 bg-[#0c0b0a] border-r border-[#e5950015] z-40 overflow-y-auto scrollbar-none transition-transform duration-200 ${
-          mobileOpen ? 'translate-x-0' : '-translate-x-full'
-        } md:translate-x-0 md:sticky md:top-0 md:h-screen md:shrink-0`}
-      >
-        {/* Push sidebar content below header on mobile */}
-        <div className="pt-12 md:pt-0">
-          {sidebarNav}
-        </div>
-      </aside>
-    </>
+        ))}
+      </nav>
+    </aside>
   );
 }

--- a/app/(golems)/golems/docs/[...slug]/page.tsx
+++ b/app/(golems)/golems/docs/[...slug]/page.tsx
@@ -131,7 +131,7 @@ export default async function DocsPage({ params }: { params: Promise<{ slug: str
   };
 
   return (
-    <div className="max-w-6xl mx-auto px-6 pt-16 md:pt-12 pb-12 flex gap-8">
+    <div className="max-w-6xl mx-auto px-6 pt-8 pb-12 flex gap-8">
       <article className="flex-1 min-w-0 max-w-3xl">
         <MDXRemote
           source={content}

--- a/app/(golems)/golems/layout.tsx
+++ b/app/(golems)/golems/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import type { Metadata } from 'next';
 import { JetBrains_Mono, Inter, IBM_Plex_Mono } from 'next/font/google';
 import './globals.css';
+import Header from './components/Header';
 import Sidebar from './components/Sidebar';
 
 const inter = Inter({
@@ -38,6 +39,7 @@ export default function GolemsRootLayout({ children }: { children: ReactNode }) 
   return (
     <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable} ${ibmPlexMono.variable}`}>
       <body className="bg-[#0c0b0a] text-[#c0b8a8] antialiased scrollbar-none">
+        <Header />
         <div className="flex min-h-screen">
           <Sidebar />
           <main className="flex-1 min-w-0 overflow-x-clip">{children}</main>


### PR DESCRIPTION
## Summary
- New sticky Header component with logo, nav links (Docs, Journey, For LLMs), and external links (etanheyman.com, GitHub)
- Visible on ALL golems pages (landing + docs) — previously the landing page had no navigation at all
- Mobile hamburger menu includes docs sidebar sections when on doc pages
- Simplified Sidebar to desktop-only docs navigation (removed duplicate mobile header, back links, and title)
- Adjusted doc page padding for new header

## Test plan
- [ ] `/golems` landing page shows header with logo and nav links
- [ ] `/golems/docs/getting-started` shows header + sidebar
- [ ] Mobile: hamburger reveals nav links + expandable doc sections
- [ ] Active link highlighting works correctly
- [ ] External links open in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/navigation changes limited to the Golems docsite layout; primary risk is responsive layout/regression in mobile navigation and doc page spacing.
> 
> **Overview**
> Adds a new sticky `Header` rendered in `app/(golems)/golems/layout.tsx`, providing global navigation (Docs/Journey/For LLMs) plus external links, with active-link styling and a mobile hamburger menu.
> 
> On mobile, the header dropdown now also exposes an expandable docs page index when on `/golems/docs/*`, and the existing `Sidebar` is simplified to **desktop-only** docs navigation (removing the prior mobile sidebar/header/overlay behavior). Doc pages adjust top padding to account for the new header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fdc0215892c9f2a7289f5435966cf2cb1efdaf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->