### PR TITLE
feat: align docs rendering with golems dashboard

### DIFF
--- a/app/(golems)/golems/components/Header.tsx
+++ b/app/(golems)/golems/components/Header.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import { Menu, X, ChevronDown } from 'lucide-react';
+import type { DocNavItem } from '../lib/docs-nav';
 
 const navLinks = [
   { label: 'Docs', href: '/golems/docs/getting-started' },
@@ -18,59 +19,11 @@ const externalLinks = [
   { label: 'GitHub', href: 'https://github.com/EtanHey/golems' },
 ];
 
-const docsSections = [
-  {
-    title: 'Getting Started',
-    items: [
-      { title: 'Introduction', href: '/golems/docs/getting-started' },
-      { title: 'Architecture', href: '/golems/docs/architecture' },
-    ],
-  },
-  {
-    title: 'Agents',
-    items: [
-      { title: 'ClaudeGolem', href: '/golems/docs/golems/claude' },
-      { title: 'RecruiterGolem', href: '/golems/docs/golems/recruiter' },
-      { title: 'TellerGolem', href: '/golems/docs/golems/teller' },
-      { title: 'CoachGolem', href: '/golems/docs/golems/coach' },
-      { title: 'ContentGolem', href: '/golems/docs/packages/content' },
-      { title: 'Content Pipelines', href: '/golems/docs/content-pipelines' },
-    ],
-  },
-  {
-    title: 'Tools & Layers',
-    items: [
-      { title: 'Email System', href: '/golems/docs/golems/email' },
-      { title: 'Job Scraping', href: '/golems/docs/golems/job-golem' },
-      { title: 'Shared Foundation', href: '/golems/docs/packages/shared' },
-      { title: 'Skills Library', href: '/golems/docs/skills' },
-      { title: 'MCP Tools', href: '/golems/docs/mcp-tools' },
-    ],
-  },
-  {
-    title: 'Infrastructure',
-    items: [
-      { title: 'Services', href: '/golems/docs/packages/services' },
-      { title: 'Zikaron (Memory)', href: '/golems/docs/packages/zikaron' },
-      { title: 'Ralph (Coding Loop)', href: '/golems/docs/packages/ralph' },
-      { title: 'Cloud Worker', href: '/golems/docs/cloud-worker' },
-      { title: 'Dashboard', href: '/golems/docs/packages/dashboard' },
-      { title: 'Orchestrator', href: '/golems/docs/packages/orchestrator' },
-      { title: 'Per-Repo Sessions', href: '/golems/docs/per-repo-sessions' },
-    ],
-  },
-  {
-    title: 'Guides',
-    items: [
-      { title: 'Environment Variables', href: '/golems/docs/configuration/env-vars' },
-      { title: 'Secrets & 1Password', href: '/golems/docs/configuration/secrets' },
-      { title: 'FAQ', href: '/golems/docs/faq' },
-      { title: 'Engineering Journey', href: '/golems/docs/journey' },
-    ],
-  },
-];
+interface Props {
+  nav: DocNavItem[];
+}
 
-export default function Header() {
+export default function Header({ nav }: Props) {
   const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
   const isDocsPage = pathname.startsWith('/golems/docs');
@@ -189,29 +142,49 @@ export default function Header() {
                 </button>
                 {docsExpanded && (
                   <div className="pl-2 space-y-3 pt-1">
-                    {docsSections.map((section) => (
-                      <div key={section.title}>
-                        <h4 className="text-[10px] font-bold uppercase tracking-widest text-[#7c6f5e] mb-1 px-3">
-                          {section.title}
-                        </h4>
-                        {section.items.map((item) => {
-                          const isActive = pathname === item.href;
-                          return (
-                            <Link
-                              key={item.href}
-                              href={item.href}
-                              className={`block px-3 py-1.5 rounded-md text-sm transition-colors ${
-                                isActive
-                                  ? 'bg-[#e5950015] text-[#e59500] font-medium'
-                                  : 'text-[#908575] hover:text-[#c0b8a8] hover:bg-[#ffffff08]'
-                              }`}
-                            >
-                              {item.title}
-                            </Link>
-                          );
-                        })}
-                      </div>
-                    ))}
+                    {nav.map((section) => {
+                      if (!section.children) {
+                        const href = `/golems/docs/${section.slug}`;
+                        const isActive = pathname === href;
+                        return (
+                          <Link
+                            key={section.slug}
+                            href={href}
+                            className={`block px-3 py-1.5 rounded-md text-sm transition-colors ${
+                              isActive
+                                ? 'bg-[#e5950015] text-[#e59500] font-medium'
+                                : 'text-[#908575] hover:text-[#c0b8a8] hover:bg-[#ffffff08]'
+                            }`}
+                          >
+                            {section.title}
+                          </Link>
+                        );
+                      }
+                      return (
+                        <div key={section.slug}>
+                          <h4 className="text-[10px] font-bold uppercase tracking-widest text-[#7c6f5e] mb-1 px-3">
+                            {section.title}
+                          </h4>
+                          {section.children.map((item) => {
+                            const href = `/golems/docs/${item.slug}`;
+                            const isActive = pathname === href;
+                            return (
+                              <Link
+                                key={item.slug}
+                                href={href}
+                                className={`block px-3 py-1.5 rounded-md text-sm transition-colors ${
+                                  isActive
+                                    ? 'bg-[#e5950015] text-[#e59500] font-medium'
+                                    : 'text-[#908575] hover:text-[#c0b8a8] hover:bg-[#ffffff08]'
+                                }`}
+                              >
+                                {item.title}
+                              </Link>
+                            );
+                          })}
+                        </div>
+                      );
+                    })}
                   </div>
                 )}
               </>

--- a/app/(golems)/golems/components/Sidebar.tsx
+++ b/app/(golems)/golems/components/Sidebar.tsx
@@ -2,70 +2,13 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import type { DocNavItem } from '../lib/docs-nav';
 
-interface SidebarItem {
-  title: string;
-  href: string;
+interface Props {
+  nav: DocNavItem[];
 }
 
-interface SidebarSection {
-  title: string;
-  items: SidebarItem[];
-}
-
-const sidebarConfig: SidebarSection[] = [
-  {
-    title: 'Getting Started',
-    items: [
-      { title: 'Introduction', href: '/golems/docs/getting-started' },
-      { title: 'Architecture', href: '/golems/docs/architecture' },
-    ],
-  },
-  {
-    title: 'Agents',
-    items: [
-      { title: 'ClaudeGolem', href: '/golems/docs/golems/claude' },
-      { title: 'RecruiterGolem', href: '/golems/docs/golems/recruiter' },
-      { title: 'TellerGolem', href: '/golems/docs/golems/teller' },
-      { title: 'CoachGolem', href: '/golems/docs/golems/coach' },
-      { title: 'ContentGolem', href: '/golems/docs/packages/content' },
-      { title: 'Content Pipelines', href: '/golems/docs/content-pipelines' },
-    ],
-  },
-  {
-    title: 'Tools & Layers',
-    items: [
-      { title: 'Email System', href: '/golems/docs/golems/email' },
-      { title: 'Job Scraping', href: '/golems/docs/golems/job-golem' },
-      { title: 'Shared Foundation', href: '/golems/docs/packages/shared' },
-      { title: 'Skills Library', href: '/golems/docs/skills' },
-      { title: 'MCP Tools', href: '/golems/docs/mcp-tools' },
-    ],
-  },
-  {
-    title: 'Infrastructure',
-    items: [
-      { title: 'Services', href: '/golems/docs/packages/services' },
-      { title: 'Zikaron (Memory)', href: '/golems/docs/packages/zikaron' },
-      { title: 'Ralph (Coding Loop)', href: '/golems/docs/packages/ralph' },
-      { title: 'Cloud Worker', href: '/golems/docs/cloud-worker' },
-      { title: 'Dashboard', href: '/golems/docs/packages/dashboard' },
-      { title: 'Orchestrator', href: '/golems/docs/packages/orchestrator' },
-      { title: 'Per-Repo Sessions', href: '/golems/docs/per-repo-sessions' },
-    ],
-  },
-  {
-    title: 'Guides',
-    items: [
-      { title: 'Environment Variables', href: '/golems/docs/configuration/env-vars' },
-      { title: 'Secrets & 1Password', href: '/golems/docs/configuration/secrets' },
-      { title: 'FAQ', href: '/golems/docs/faq' },
-      { title: 'Engineering Journey', href: '/golems/docs/journey' },
-    ],
-  },
-];
-
-export default function Sidebar() {
+export default function Sidebar({ nav }: Props) {
   const pathname = usePathname();
 
   const isDocsPage = pathname.startsWith('/golems/docs');
@@ -78,32 +21,56 @@ export default function Sidebar() {
       className="hidden md:block w-64 shrink-0 sticky top-12 h-[calc(100vh-3rem)] overflow-y-auto scrollbar-none bg-[#0c0b0a] border-r border-[#e5950015]"
     >
       <nav className="flex flex-col gap-6 p-4">
-        {sidebarConfig.map((section) => (
-          <div key={section.title}>
-            <h3 className="text-[10px] font-bold uppercase tracking-widest text-[#7c6f5e] mb-2">
-              {section.title}
-            </h3>
-            <ul className="space-y-0.5">
-              {section.items.map((item) => {
-                const isActive = pathname === item.href;
-                return (
-                  <li key={item.href}>
-                    <Link
-                      href={item.href}
-                      className={`block px-3 py-1.5 rounded-md text-sm transition-colors ${
-                        isActive
-                          ? 'bg-[#e5950015] text-[#e59500] font-medium'
-                          : 'text-[#908575] hover:text-[#c0b8a8] hover:bg-[#ffffff08]'
-                      }`}
-                    >
-                      {item.title}
-                    </Link>
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
-        ))}
+        {nav.map((section) => {
+          // Top-level items without children = standalone page
+          if (!section.children) {
+            const href = `/golems/docs/${section.slug}`;
+            const isActive = pathname === href;
+            return (
+              <div key={section.slug}>
+                <Link
+                  href={href}
+                  className={`block px-3 py-1.5 rounded-md text-sm transition-colors ${
+                    isActive
+                      ? 'bg-[#e5950015] text-[#e59500] font-medium'
+                      : 'text-[#908575] hover:text-[#c0b8a8] hover:bg-[#ffffff08]'
+                  }`}
+                >
+                  {section.title}
+                </Link>
+              </div>
+            );
+          }
+
+          // Category with children
+          return (
+            <div key={section.slug}>
+              <h3 className="text-[10px] font-bold uppercase tracking-widest text-[#7c6f5e] mb-2">
+                {section.title}
+              </h3>
+              <ul className="space-y-0.5">
+                {section.children.map((item) => {
+                  const href = `/golems/docs/${item.slug}`;
+                  const isActive = pathname === href;
+                  return (
+                    <li key={item.slug}>
+                      <Link
+                        href={href}
+                        className={`block px-3 py-1.5 rounded-md text-sm transition-colors ${
+                          isActive
+                            ? 'bg-[#e5950015] text-[#e59500] font-medium'
+                            : 'text-[#908575] hover:text-[#c0b8a8] hover:bg-[#ffffff08]'
+                        }`}
+                      >
+                        {item.title}
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          );
+        })}
       </nav>
     </aside>
   );

--- a/app/(golems)/golems/components/TableOfContents.tsx
+++ b/app/(golems)/golems/components/TableOfContents.tsx
@@ -23,7 +23,7 @@ export default function TableOfContents() {
     const article = document.querySelector('article');
     if (!article) return;
 
-    const els = article.querySelectorAll('h2, h3, h4');
+    const els = article.querySelectorAll('h2, h3');
     const items: TocItem[] = [];
     for (const el of els) {
       if (el.id && el.textContent) {

--- a/app/(golems)/golems/layout.tsx
+++ b/app/(golems)/golems/layout.tsx
@@ -4,6 +4,7 @@ import { JetBrains_Mono, Inter, IBM_Plex_Mono } from 'next/font/google';
 import './globals.css';
 import Header from './components/Header';
 import Sidebar from './components/Sidebar';
+import { getDocsNav, type DocNavItem } from './lib/docs-nav';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -36,12 +37,14 @@ export const metadata: Metadata = {
 };
 
 export default function GolemsRootLayout({ children }: { children: ReactNode }) {
+  const nav = getDocsNav();
+
   return (
     <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable} ${ibmPlexMono.variable}`}>
       <body className="bg-[#0c0b0a] text-[#c0b8a8] antialiased scrollbar-none">
-        <Header />
+        <Header nav={nav} />
         <div className="flex min-h-screen">
-          <Sidebar />
+          <Sidebar nav={nav} />
           <main className="flex-1 min-w-0 overflow-x-clip">{children}</main>
         </div>
       </body>

--- a/app/(golems)/golems/lib/docs-nav.ts
+++ b/app/(golems)/golems/lib/docs-nav.ts
@@ -1,0 +1,137 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+
+const DOCS_DIR = path.join(process.cwd(), "content", "golems");
+
+export type DocNavItem = {
+  slug: string;
+  title: string;
+  position?: number;
+  children?: DocNavItem[];
+};
+
+/**
+ * Read _category_.json for a directory if it exists.
+ */
+function readCategory(dir: string): { label: string; position: number } | null {
+  const catFile = path.join(dir, "_category_.json");
+  if (!fs.existsSync(catFile)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(catFile, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get all doc slugs by walking the content directory.
+ */
+function getAllDocSlugs(): string[][] {
+  const slugs: string[][] = [];
+
+  function walk(dir: string, prefix: string[]) {
+    if (!fs.existsSync(dir)) return;
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        walk(path.join(dir, entry.name), [...prefix, entry.name]);
+      } else if (entry.name.endsWith(".md")) {
+        const slug = entry.name.replace(/\.md$/, "");
+        slugs.push([...prefix, slug]);
+      }
+    }
+  }
+
+  walk(DOCS_DIR, []);
+  return slugs;
+}
+
+/**
+ * Load title and sidebar_position from a doc's frontmatter.
+ */
+function getDocMeta(parts: string[]): { title: string; sidebarPosition?: number } | null {
+  const filePath = path.join(DOCS_DIR, ...parts) + ".md";
+  if (!fs.existsSync(filePath)) return null;
+
+  const raw = fs.readFileSync(filePath, "utf-8");
+  const { data, content } = matter(raw);
+
+  let title = data.title;
+  if (!title) {
+    const h1Match = content.match(/^#\s+(.+)/m);
+    title = h1Match ? h1Match[1] : parts[parts.length - 1];
+  }
+
+  return { title, sidebarPosition: data.sidebar_position };
+}
+
+/**
+ * Build the docs navigation tree from filesystem + frontmatter.
+ * Mirrors packages/dashboard/src/lib/docs/index.ts getDocsNav().
+ */
+export function getDocsNav(): DocNavItem[] {
+  const topLevel: DocNavItem[] = [];
+  const categories: Record<string, { label: string; position: number; children: DocNavItem[] }> = {};
+
+  const slugs = getAllDocSlugs();
+
+  for (const parts of slugs) {
+    const meta = getDocMeta(parts);
+    if (!meta) continue;
+
+    const item: DocNavItem = {
+      slug: parts.join("/"),
+      title: meta.title,
+      position: meta.sidebarPosition,
+    };
+
+    if (parts.length === 1) {
+      topLevel.push(item);
+    } else {
+      const cat = parts[0];
+      if (!categories[cat]) {
+        const catMeta = readCategory(path.join(DOCS_DIR, cat));
+        categories[cat] = {
+          label: catMeta?.label ?? cat.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()),
+          position: catMeta?.position ?? 999,
+          children: [],
+        };
+      }
+      categories[cat].children.push(item);
+    }
+  }
+
+  // Sort top-level by position then title
+  topLevel.sort((a, b) => (a.position ?? 999) - (b.position ?? 999) || a.title.localeCompare(b.title));
+
+  // Sort category children
+  for (const cat of Object.values(categories)) {
+    cat.children.sort((a, b) => (a.position ?? 999) - (b.position ?? 999) || a.title.localeCompare(b.title));
+  }
+
+  // Build final nav: top-level items first, then categories sorted by position
+  const sortedCats = Object.entries(categories).sort(([, a], [, b]) => a.position - b.position);
+
+  const navItems: DocNavItem[] = [...topLevel];
+  for (const [cat, { label, children }] of sortedCats) {
+    navItems.push({ slug: cat, title: label, children });
+  }
+
+  return navItems;
+}
+
+/**
+ * Flatten nav items into ordered list of leaf pages (for prev/next).
+ */
+export function flattenNav(items: DocNavItem[]): { slug: string; title: string }[] {
+  const result: { slug: string; title: string }[] = [];
+  for (const item of items) {
+    if (item.children) {
+      result.push(...flattenNav(item.children));
+    } else {
+      result.push({ slug: item.slug, title: item.title });
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

- **Auto-generated nav**: Port `getDocsNav()`/`flattenNav()` from golems dashboard — sidebar, header, and prev/next links now generated from frontmatter + `_category_.json`
- **Remove hardcoded nav**: Replaced `sidebarConfig` (Sidebar.tsx), `docsSections` (Header.tsx), and `DOC_ORDER` (page.tsx) with auto-generated data
- **H1 stripping**: Strip first H1 from markdown content to avoid duplicate title rendering (matches dashboard)
- **TOC alignment**: Changed heading depth from h2+h3+h4 to h2+h3 only (matches dashboard)
- **Server → Client data flow**: Layout generates nav (server) and passes to Sidebar/Header (client) as props

Part of Phase 6 (rendering alignment) — companion PR: golems#206

## Test plan

- [x] TypeScript compilation passes (no type errors)
- [x] Next.js build compiles successfully (pre-existing 404 error unrelated)
- [x] All 10 tests pass
- [x] Sidebar renders from auto-generated nav
- [x] Mobile nav renders from same data
- [x] Prev/next links use flattenNav() order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Navigation and prev/next ordering now depend on filesystem/frontmatter parsing, so missing/invalid `_category_.json` or metadata could change sidebar order or break links. Rendering tweaks (H1 stripping, TOC depth) may subtly change doc layouts but are localized to the docs UI.
> 
> **Overview**
> Docs navigation is no longer hardcoded: a new `lib/docs-nav.ts` builds a nav tree by walking `content/golems`, reading doc frontmatter (title/`sidebar_position`) and optional `_category_.json`, and `layout.tsx` generates this nav on the server and passes it into the client `Header` and `Sidebar`.
> 
> Docs pages now use that same generated order for prev/next links via `flattenNav(getDocsNav())`, strip the first markdown H1 before MDX rendering to avoid duplicate titles, and the table of contents only indexes `h2`/`h3` (dropping `h4`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b05268149e34a25120e9359bc87a2886e4dc790. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->