### PR TITLE
fix: center logo in nav pill

### DIFF
--- a/app/components/navigation/Nav.tsx
+++ b/app/components/navigation/Nav.tsx
@@ -25,15 +25,13 @@ const Nav = () => {
     <nav className="bg-background sticky top-0 z-10 h-full w-full px-4.5 pt-3 pb-4">
       <div className="relative flex h-15 items-center justify-between gap-3.75 rounded-[80px] bg-white px-4 py-2.5">
         <SocialLinks iconContainerClassName="flex items-center justify-center p-1 rounded-full bg-blue-50 shadow-[0px_1px_1px_0px_#00004326]" />
-        <div className="flex w-full items-center justify-between gap-2">
-          <Link href="/" className="flex items-center justify-center">
-            <Logo />
-          </Link>
-          <div
-            className={`flex items-center px-[6.5px] py-2.5 ${isOpen ? "bg-blue-900" : "bg-blue-500"} justify-center gap-2 rounded-full shadow-[0px_2px_1px_0px_#00004326]`}
-          >
-            <MenuTrigger isOpen={isOpen} onClick={() => setIsOpen(!isOpen)} />
-          </div>
+        <Link href="/" className="absolute left-1/2 -translate-x-1/2 flex items-center justify-center">
+          <Logo />
+        </Link>
+        <div
+          className={`flex items-center px-[6.5px] py-2.5 ${isOpen ? "bg-blue-900" : "bg-blue-500"} justify-center gap-2 rounded-full shadow-[0px_2px_1px_0px_#00004326]`}
+        >
+          <MenuTrigger isOpen={isOpen} onClick={() => setIsOpen(!isOpen)} />
         </div>
       </div>
       {/* Backdrop overlay to close menu on tap outside */}

--- a/app/components/navigation/Nav.tsx
+++ b/app/components/navigation/Nav.tsx
@@ -25,7 +25,7 @@ const Nav = () => {
     <nav className="bg-background sticky top-0 z-10 h-full w-full px-4.5 pt-3 pb-4">
       <div className="relative flex h-15 items-center justify-between gap-3.75 rounded-[80px] bg-white px-4 py-2.5">
         <SocialLinks iconContainerClassName="flex items-center justify-center p-1 rounded-full bg-blue-50 shadow-[0px_1px_1px_0px_#00004326]" />
-        <Link href="/" className="absolute left-1/2 -translate-x-1/2 flex items-center justify-center">
+        <Link href="/" aria-label="Home" className="absolute left-1/2 z-10 -translate-x-1/2 flex items-center justify-center">
           <Logo />
         </Link>
         <div


### PR DESCRIPTION
## Summary
- Logo was visually off-center in the white nav pill because SocialLinks (left) and MenuTrigger (right) have different widths
- Fixed by absolutely positioning the Logo with `left-1/2 -translate-x-1/2` inside the already-relative nav container
- SocialLinks and MenuTrigger remain at edges via `justify-between`

## Test plan
- [ ] Verify logo is visually centered on mobile
- [ ] Verify logo is visually centered on desktop
- [ ] Verify menu trigger still works (open/close)
- [ ] Verify social links are still clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure layout/CSS restructuring in the navigation header; no routing, data, or auth logic changes.
> 
> **Overview**
> Adjusts the nav pill layout so the `Logo` link is visually centered regardless of the differing widths of `SocialLinks` and the menu trigger.
> 
> This moves the home `Link`/`Logo` to absolute centering (`left-1/2` + `-translate-x-1/2`) within the existing relative container while keeping `SocialLinks` left-aligned and `MenuTrigger` right-aligned, with menu open/close behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2a9b039b537434366b043695a44b828bc4cea48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Navigation layout adjusted: logo repositioned to center alignment with menu trigger moved to separate container. Visual structure and menu behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->