### PR TITLE
fix: full-height loading skeleton to prevent MiniSiteNav jump

### DIFF
--- a/app/(portfolio)/projects/[slug]/loading.tsx
+++ b/app/(portfolio)/projects/[slug]/loading.tsx
@@ -1,11 +1,87 @@
 export default function Loading() {
   return (
-    <main className="relative z-10 mx-auto max-w-5xl px-4 py-8 md:px-8 md:py-16">
-      <div className="animate-pulse space-y-8">
-        <div className="h-6 w-32 rounded bg-white/5" />
-        <div className="h-10 w-80 rounded bg-white/5" />
-        <div className="h-4 w-96 rounded bg-white/[0.03]" />
-        <div className="h-4 w-72 rounded bg-white/[0.03]" />
+    <main className="relative z-10 mx-auto min-h-screen max-w-5xl px-4 py-8 md:px-8 md:py-16">
+      <div className="animate-pulse">
+        {/* Back link */}
+        <div className="mb-12">
+          <div className="h-4 w-28 rounded bg-white/5" />
+        </div>
+
+        {/* Hero: logo + title + description + badges */}
+        <section className="mb-14">
+          <div className="flex flex-col gap-6 md:flex-row md:items-start md:gap-10">
+            <div className="h-[100px] w-[100px] flex-shrink-0 rounded-3xl bg-white/5 md:h-[140px] md:w-[140px]" />
+            <div className="flex-1 space-y-4">
+              <div className="h-10 w-72 rounded bg-white/5 md:h-14 md:w-96" />
+              <div className="space-y-2">
+                <div className="h-4 w-full max-w-[520px] rounded bg-white/[0.03]" />
+                <div className="h-4 w-full max-w-[400px] rounded bg-white/[0.03]" />
+              </div>
+              <div className="flex gap-3 pt-1">
+                <div className="h-9 w-32 rounded-full bg-white/5" />
+                <div className="h-9 w-24 rounded-full bg-white/[0.03]" />
+                <div className="h-9 w-20 rounded-full bg-white/[0.03]" />
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Stats bar */}
+        <section className="mb-14">
+          <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-20 rounded-2xl border border-white/[0.06] bg-white/[0.02]"
+              />
+            ))}
+          </div>
+        </section>
+
+        {/* Built with */}
+        <section className="mb-14">
+          <div className="mb-6 h-3 w-20 rounded bg-white/5" />
+          <div className="grid grid-cols-6 gap-6 md:grid-cols-8">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div
+                key={i}
+                className="aspect-square rounded-xl bg-white/[0.03]"
+              />
+            ))}
+          </div>
+        </section>
+
+        {/* Key features */}
+        <section className="mb-14">
+          <div className="mb-6 h-3 w-24 rounded bg-white/5" />
+          <div className="grid gap-4 md:grid-cols-2">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-36 rounded-2xl border border-white/[0.06] bg-white/[0.02]"
+              />
+            ))}
+          </div>
+        </section>
+
+        {/* How it works */}
+        <section className="mb-14">
+          <div className="mb-6 h-3 w-28 rounded bg-white/5" />
+          <div className="space-y-4">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-16 rounded-2xl border border-white/[0.06] bg-white/[0.02]"
+              />
+            ))}
+          </div>
+        </section>
+
+        {/* Get started */}
+        <section className="mb-14">
+          <div className="mb-6 h-3 w-24 rounded bg-white/5" />
+          <div className="h-48 rounded-2xl border border-white/[0.06] bg-white/[0.02]" />
+        </section>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- Replaces the minimal 4-line loading skeleton with a full-page-height skeleton that mirrors the real page layout
- Includes hero (logo + title + description + badges), stats bar, tech grid, features grid, architecture section, and code block placeholders
- Uses `min-h-screen` to keep the sticky `MiniSiteNav` (at `top-[88px]`) stable during tab transitions
- Maintains existing `animate-pulse` + `bg-white/5` / `bg-white/[0.03]` color pattern

## Test plan
- [ ] Navigate between mini-site tabs (Overview → Architecture → Features → Get Started) for brainlayer, voicelayer, golems
- [ ] Verify MiniSiteNav no longer jumps down during loading state
- [ ] Verify skeleton appearance matches the general layout proportions of real pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only loading-state markup/CSS changes; main risk is minor visual/layout regressions (spacing, responsiveness, or performance) rather than logic or data issues.
> 
> **Overview**
> Updates `app/(portfolio)/projects/[slug]/loading.tsx` from a small generic skeleton to a **full-page, layout-shaped** loading state (back link, hero block, stats, tech grid, feature cards, how-it-works rows, and a get-started panel).
> 
> Adds `min-h-screen` on the main container and uses repeated placeholder grids/cards to better match final layout, reducing visible layout shift under the sticky `MiniSiteNav` during tab navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3994cc5c9372e92f5e990a97a5e85b28e4b3434b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->