### PR TITLE
fix: click-to-copy tagline + Shiki syntax highlighting

### DIFF
--- a/app/(portfolio)/projects/[slug]/components/CodeBlock.tsx
+++ b/app/(portfolio)/projects/[slug]/components/CodeBlock.tsx
@@ -62,9 +62,16 @@ export function CodeBlock({
       </div>
       {/* Code content */}
       <div className="p-5">
-        <pre className="overflow-x-auto font-mono text-[13px] leading-relaxed text-white/75 md:text-[14px]">
-          <code>{tabs[activeTab].command}</code>
-        </pre>
+        {tabs[activeTab].highlightedHtml ? (
+          <div
+            className="overflow-x-auto font-mono text-[13px] leading-relaxed md:text-[14px] [&_pre]:!bg-transparent [&_pre]:!p-0 [&_code]:!bg-transparent"
+            dangerouslySetInnerHTML={{ __html: tabs[activeTab].highlightedHtml }}
+          />
+        ) : (
+          <pre className="overflow-x-auto font-mono text-[13px] leading-relaxed text-white/75 md:text-[14px]">
+            <code>{tabs[activeTab].command}</code>
+          </pre>
+        )}
       </div>
     </div>
   );

--- a/app/(portfolio)/projects/[slug]/components/TaglineBadge.tsx
+++ b/app/(portfolio)/projects/[slug]/components/TaglineBadge.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+import { Terminal, Check } from "lucide-react";
+
+export function TaglineBadge({
+  tagline,
+  accentColor,
+  accentColorRgb,
+}: {
+  tagline: string;
+  accentColor: string;
+  accentColorRgb: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(tagline);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="flex items-center gap-2 rounded-full border px-4 py-2 font-mono text-[12px] transition-colors hover:brightness-125 md:text-[13px]"
+      style={{
+        borderColor: `rgba(${accentColorRgb}, 0.3)`,
+        color: accentColor,
+        backgroundColor: `rgba(${accentColorRgb}, 0.08)`,
+      }}
+      title="Click to copy"
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5" />
+      ) : (
+        <Terminal className="h-3.5 w-3.5" />
+      )}
+      {copied ? "Copied!" : tagline}
+    </button>
+  );
+}

--- a/app/(portfolio)/projects/[slug]/page.tsx
+++ b/app/(portfolio)/projects/[slug]/page.tsx
@@ -8,7 +8,6 @@ import {
   BookOpen,
   ArrowLeft,
   ExternalLink,
-  Terminal,
 } from "lucide-react";
 import {
   TechIconWrapper,
@@ -24,6 +23,8 @@ import { CodeBlock } from "./components/CodeBlock";
 import { CrossLinks } from "./components/CrossLinks";
 import { JourneyTimeline } from "./components/JourneyTimeline";
 import { ArchitectureDiagram } from "./components/ArchitectureDiagram";
+import { TaglineBadge } from "./components/TaglineBadge";
+import { highlightCode } from "@/lib/highlight";
 
 export default async function ProjectPage({
   params,
@@ -42,6 +43,21 @@ export default async function ProjectPage({
   const allProjects = await getAllProjects();
 
   const isGitPrivate = project.gitUrl === "private";
+
+  // Pre-highlight install tab commands server-side
+  const highlightedTabs = showcase?.installTabs
+    ? await Promise.all(
+        showcase.installTabs.map(async (tab) => {
+          const lang = tab.label.toLowerCase().includes("mcp") ||
+            tab.label.toLowerCase().includes("config") ||
+            tab.label.toLowerCase().includes("json")
+            ? "json"
+            : "bash";
+          const highlightedHtml = await highlightCode(tab.command, lang);
+          return { ...tab, highlightedHtml };
+        }),
+      )
+    : undefined;
 
   return (
     <main className="relative z-10 mx-auto max-w-5xl px-4 py-8 md:px-8 md:py-16">
@@ -110,17 +126,11 @@ export default async function ProjectPage({
             {/* Badges + action buttons */}
             <div className="flex flex-wrap items-center gap-3">
               {showcase?.tagline && (
-                <div
-                  className="flex items-center gap-2 rounded-full border px-4 py-2 font-mono text-[12px] md:text-[13px]"
-                  style={{
-                    borderColor: `rgba(${accent.colorRgb}, 0.3)`,
-                    color: accent.color,
-                    backgroundColor: `rgba(${accent.colorRgb}, 0.08)`,
-                  }}
-                >
-                  <Terminal className="h-3.5 w-3.5" />
-                  {showcase.tagline}
-                </div>
+                <TaglineBadge
+                  tagline={showcase.tagline}
+                  accentColor={accent.color}
+                  accentColorRgb={accent.colorRgb}
+                />
               )}
 
               {!isGitPrivate && project.gitUrl && (
@@ -229,7 +239,7 @@ export default async function ProjectPage({
             Get started
           </h2>
           <CodeBlock
-            tabs={showcase.installTabs}
+            tabs={highlightedTabs ?? showcase.installTabs}
             accentColor={accent.color}
           />
         </section>

--- a/app/(portfolio)/projects/[slug]/project-showcase-config.ts
+++ b/app/(portfolio)/projects/[slug]/project-showcase-config.ts
@@ -17,6 +17,7 @@ export interface ProjectFeature {
 export interface InstallTab {
   label: string;
   command: string;
+  highlightedHtml?: string;
 }
 
 export interface ProjectAccent {


### PR DESCRIPTION
## Summary
- Extract `TaglineBadge` client component — clicking the tagline badge (e.g. "pip install brainlayer") copies text to clipboard with Terminal→Check icon feedback
- Add Shiki syntax highlighting to CodeBlock install tabs — commands pre-highlighted server-side (bash for commands, json for MCP configs), rendered via `dangerouslySetInnerHTML`

## Test plan
- [ ] Visit a mini-site project page (brainlayer, voicelayer, golems)
- [ ] Click the tagline badge — verify text copies to clipboard and icon swaps to checkmark for 2s
- [ ] Check "Get started" code block — verify syntax colors appear for all tabs
- [ ] Verify MCP Config tab renders JSON highlighting, other tabs render bash highlighting
- [ ] Confirm `npm run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces `dangerouslySetInnerHTML` rendering of server-generated highlighted HTML and adds clipboard interactions; low functional scope but requires confidence in HTML generation/sanitization and browser clipboard behavior.
> 
> **Overview**
> Project mini-site pages now render the tagline as a clickable `TaglineBadge` that copies the tagline text to the clipboard and shows a brief checkmark/"Copied!" state.
> 
> The “Get started” `CodeBlock` now supports optional pre-highlighted HTML per tab: `page.tsx` precomputes Shiki-highlighted markup server-side via `highlightCode` (choosing `json` for MCP/config tabs, otherwise `bash`) and `CodeBlock` conditionally renders it via `dangerouslySetInnerHTML`, falling back to plain text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c4f2f8825d1084397b173478fc95d0fdab7ad64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->