### PR TITLE
fix: mobile overflow, persistent layout header, skeleton polish

### DIFF
--- a/app/(portfolio)/projects/[slug]/architecture/page.tsx
+++ b/app/(portfolio)/projects/[slug]/architecture/page.tsx
@@ -10,7 +10,6 @@ import { ArchitectureDiagram } from "../components/ArchitectureDiagram";
 import { ArchCodeBlock } from "../components/ArchCodeBlock";
 import { InsightCallout } from "../components/InsightCallout";
 import { ComparisonTable } from "../components/ComparisonTable";
-import { SubpageHeader } from "../components/SubpageHeader";
 import type { Metadata } from "next";
 
 export function generateStaticParams() {
@@ -62,10 +61,9 @@ export default async function ArchitecturePage({
   const accent = showcase?.accent ?? getDefaultAccent();
 
   return (
-    <main className="relative z-10 mx-auto max-w-5xl px-4 py-8 md:px-8 md:py-16">
+    <main className="relative z-10 mx-auto max-w-5xl overflow-x-hidden px-4 py-8 md:px-8 md:py-16">
       {/* Page header */}
       <section className="mb-16">
-        <SubpageHeader slug={slug} title={project.title} logoUrl={project.logoUrl} />
         <h1 className="mb-3 font-mono text-[11px] tracking-[0.2em] text-white/30 uppercase md:text-[12px]">
           Architecture
         </h1>

--- a/app/(portfolio)/projects/[slug]/components/ArchCodeBlock.tsx
+++ b/app/(portfolio)/projects/[slug]/components/ArchCodeBlock.tsx
@@ -79,14 +79,14 @@ export function ArchCodeBlock({
       </div>
 
       {/* Code */}
-      <div className="p-5">
+      <div className="overflow-x-auto p-4 md:p-5">
         {highlightedHtml ? (
           <div
-            className="overflow-x-auto font-mono text-[12px] leading-relaxed md:text-[13px] [&_pre]:!bg-transparent [&_pre]:!p-0 [&_code]:!bg-transparent"
+            className="font-mono text-[11px] leading-relaxed md:text-[13px] [&_pre]:!bg-transparent [&_pre]:!p-0 [&_pre]:overflow-x-auto [&_code]:!bg-transparent"
             dangerouslySetInnerHTML={{ __html: highlightedHtml }}
           />
         ) : (
-          <pre className="overflow-x-auto font-mono text-[12px] leading-relaxed text-white/70 md:text-[13px]">
+          <pre className="overflow-x-auto font-mono text-[11px] leading-relaxed text-white/70 md:text-[13px]">
             <code>{code}</code>
           </pre>
         )}

--- a/app/(portfolio)/projects/[slug]/components/ComparisonTable.tsx
+++ b/app/(portfolio)/projects/[slug]/components/ComparisonTable.tsx
@@ -45,7 +45,7 @@ export function ComparisonTable({
       }}
     >
       <div className="overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-        <table className="w-full min-w-[500px]">
+        <table className="w-full min-w-[360px] md:min-w-[500px]">
           <thead>
             <tr
               style={{
@@ -55,7 +55,7 @@ export function ComparisonTable({
               {headers.map((header, i) => (
                 <th
                   key={i}
-                  className={`border-b px-4 py-3 text-left font-mono text-[11px] tracking-[0.1em] uppercase ${
+                  className={`border-b px-2.5 py-2.5 text-left font-mono text-[10px] tracking-[0.1em] uppercase md:px-4 md:py-3 md:text-[11px] ${
                     i === 0 ? "text-white/30" : "text-white/50"
                   }`}
                   style={{
@@ -81,7 +81,7 @@ export function ComparisonTable({
                 {row.map((cell, ci) => (
                   <td
                     key={ci}
-                    className={`border-b px-4 py-2.5 font-mono text-[12px] md:text-[13px] ${
+                    className={`border-b px-2.5 py-2 font-mono text-[11px] md:px-4 md:py-2.5 md:text-[13px] ${
                       ci === 0
                         ? "font-medium text-white/50"
                         : ci === 1

--- a/app/(portfolio)/projects/[slug]/components/FeatureSectionRow.tsx
+++ b/app/(portfolio)/projects/[slug]/components/FeatureSectionRow.tsx
@@ -90,7 +90,7 @@ export function FeatureSectionRow({
       }}
     >
       {/* Text side */}
-      <div className="flex-1">
+      <div className="min-w-0 flex-1">
         {/* Icon + number */}
         <div className="mb-4 flex items-center gap-3">
           <div
@@ -127,7 +127,7 @@ export function FeatureSectionRow({
       </div>
 
       {/* Visual side */}
-      <div className="flex-1">
+      <div className="min-w-0 flex-1">
         {section.codeExample && (
           <ArchCodeBlock
             code={section.codeExample.code}

--- a/app/(portfolio)/projects/[slug]/components/StepCard.tsx
+++ b/app/(portfolio)/projects/[slug]/components/StepCard.tsx
@@ -73,7 +73,7 @@ export function StepCard({ step, accentColor, accentColorRgb, isLast, commandHig
       </div>
 
       {/* Content */}
-      <div className={`flex-1 ${!isLast ? "pb-10" : ""}`}>
+      <div className={`min-w-0 flex-1 ${!isLast ? "pb-10" : ""}`}>
         <h3 className="mb-2 font-[Nutmeg] text-[17px] font-semibold text-white md:text-[19px]">
           {step.title}
         </h3>

--- a/app/(portfolio)/projects/[slug]/components/SubpageHeader.tsx
+++ b/app/(portfolio)/projects/[slug]/components/SubpageHeader.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { usePathname } from "next/navigation";
 
 export function SubpageHeader({
   slug,
@@ -11,6 +14,13 @@ export function SubpageHeader({
   title: string;
   logoUrl: string | null;
 }) {
+  const pathname = usePathname();
+  const basePath = `/projects/${slug}`;
+
+  // Hide on overview page — it has its own hero section
+  const isOverview = pathname === basePath || pathname === `${basePath}/`;
+  if (isOverview) return null;
+
   const isSvg =
     logoUrl &&
     (logoUrl.toLowerCase().endsWith(".svg") ||
@@ -21,37 +31,39 @@ export function SubpageHeader({
     .replace("#logo", "");
 
   return (
-    <div className="mb-8 flex items-center gap-3">
-      <Link
-        href={`/projects/${slug}`}
-        className="flex items-center gap-3 transition-opacity hover:opacity-80"
-      >
-        {cleanLogoUrl && (
-          <div className="relative h-[40px] w-[40px] flex-shrink-0 overflow-hidden rounded-xl">
-            {isSvg ? (
-              <>
-                <div className="absolute inset-0 bg-blue-50" />
-                <img
+    <div className="mx-auto max-w-5xl px-4 pt-6 pb-0 md:px-8">
+      <div className="flex items-center gap-3">
+        <Link
+          href={basePath}
+          className="flex items-center gap-3 transition-opacity hover:opacity-80"
+        >
+          {cleanLogoUrl && (
+            <div className="relative h-[40px] w-[40px] flex-shrink-0 overflow-hidden rounded-xl">
+              {isSvg ? (
+                <>
+                  <div className="absolute inset-0 bg-blue-50" />
+                  <img
+                    src={cleanLogoUrl}
+                    alt={`${title} logo`}
+                    className="relative h-full w-full object-contain p-1.5"
+                  />
+                </>
+              ) : (
+                <Image
                   src={cleanLogoUrl}
                   alt={`${title} logo`}
-                  className="relative h-full w-full object-contain p-1.5"
+                  fill
+                  className="object-contain"
                 />
-              </>
-            ) : (
-              <Image
-                src={cleanLogoUrl}
-                alt={`${title} logo`}
-                fill
-                className="object-contain"
-              />
-            )}
-          </div>
-        )}
-        <span className="font-[Nutmeg] text-[16px] font-bold text-white/70 md:text-[18px]">
-          {title}
-        </span>
-      </Link>
-      <ArrowLeft className="h-3 w-3 rotate-180 text-white/25" />
+              )}
+            </div>
+          )}
+          <span className="font-[Nutmeg] text-[16px] font-bold text-white/70 md:text-[18px]">
+            {title}
+          </span>
+        </Link>
+        <ArrowLeft className="h-3 w-3 rotate-180 text-white/25" />
+      </div>
     </div>
   );
 }

--- a/app/(portfolio)/projects/[slug]/docs/page.tsx
+++ b/app/(portfolio)/projects/[slug]/docs/page.tsx
@@ -7,7 +7,6 @@ import {
 } from "../project-showcase-config";
 import { getGettingStartedData } from "../getting-started-config";
 import { StepCard } from "../components/StepCard";
-import { SubpageHeader } from "../components/SubpageHeader";
 import type { Metadata } from "next";
 
 export function generateStaticParams() {
@@ -59,10 +58,9 @@ export default async function DocsPage({
   const accent = showcase?.accent ?? getDefaultAccent();
 
   return (
-    <main className="relative z-10 mx-auto max-w-5xl px-4 py-8 md:px-8 md:py-16">
+    <main className="relative z-10 mx-auto max-w-5xl overflow-x-hidden px-4 py-8 md:px-8 md:py-16">
       {/* Page header */}
       <section className="mb-16">
-        <SubpageHeader slug={slug} title={project.title} logoUrl={project.logoUrl} />
         <h1 className="mb-3 font-mono text-[11px] tracking-[0.2em] text-white/30 uppercase md:text-[12px]">
           Get started
         </h1>

--- a/app/(portfolio)/projects/[slug]/features/page.tsx
+++ b/app/(portfolio)/projects/[slug]/features/page.tsx
@@ -7,7 +7,6 @@ import {
 } from "../project-showcase-config";
 import { getFeaturesData } from "../features-config";
 import { FeatureSectionRow } from "../components/FeatureSectionRow";
-import { SubpageHeader } from "../components/SubpageHeader";
 import type { Metadata } from "next";
 
 export function generateStaticParams() {
@@ -59,10 +58,9 @@ export default async function FeaturesPage({
   const accent = showcase?.accent ?? getDefaultAccent();
 
   return (
-    <main className="relative z-10 mx-auto max-w-5xl px-4 py-8 md:px-8 md:py-16">
+    <main className="relative z-10 mx-auto max-w-5xl overflow-x-hidden px-4 py-8 md:px-8 md:py-16">
       {/* Page header */}
       <section className="mb-16">
-        <SubpageHeader slug={slug} title={project.title} logoUrl={project.logoUrl} />
         <h1 className="mb-3 font-mono text-[11px] tracking-[0.2em] text-white/30 uppercase md:text-[12px]">
           Features
         </h1>

--- a/app/(portfolio)/projects/[slug]/layout.tsx
+++ b/app/(portfolio)/projects/[slug]/layout.tsx
@@ -3,7 +3,9 @@ import {
   getDefaultAccent,
   isMiniSiteProject,
 } from "./project-showcase-config";
+import { getProjectBySlugOrId } from "@/lib/projects";
 import { MiniSiteNav } from "./components/MiniSiteNav";
+import { SubpageHeader } from "./components/SubpageHeader";
 
 export default async function ProjectLayout({
   children,
@@ -20,6 +22,7 @@ export default async function ProjectLayout({
 
   const config = getProjectShowcaseConfig(slug);
   const accent = config?.accent ?? getDefaultAccent();
+  const project = await getProjectBySlugOrId(slug);
 
   return (
     <>
@@ -28,6 +31,10 @@ export default async function ProjectLayout({
         accentColor={accent.color}
         accentColorRgb={accent.colorRgb}
       />
+      {/* Persistent project identity for sub-pages (overview has its own hero) */}
+      {project && (
+        <SubpageHeader slug={slug} title={project.title} logoUrl={project.logoUrl} />
+      )}
       {children}
     </>
   );

--- a/app/(portfolio)/projects/[slug]/loading.tsx
+++ b/app/(portfolio)/projects/[slug]/loading.tsx
@@ -1,6 +1,6 @@
 export default function Loading() {
   return (
-    <main className="relative z-10 mx-auto min-h-screen max-w-5xl px-4 py-8 md:px-8 md:py-16">
+    <main className="relative z-10 mx-auto min-h-screen max-w-5xl overflow-x-hidden px-4 py-8 md:px-8 md:py-16">
       <div className="animate-pulse">
         {/* Back link */}
         <div className="mb-12">
@@ -11,19 +11,24 @@ export default function Loading() {
         <section className="mb-14">
           <div className="flex flex-col gap-6 md:flex-row md:items-start md:gap-10">
             <div className="h-[100px] w-[100px] flex-shrink-0 rounded-3xl bg-white/5 md:h-[140px] md:w-[140px]" />
-            <div className="flex-1 space-y-4">
-              <div className="h-10 w-72 rounded bg-white/5 md:h-14 md:w-96" />
+            <div className="min-w-0 flex-1 space-y-4">
+              <div className="h-10 w-full max-w-[288px] rounded bg-white/5 md:h-14 md:max-w-[384px]" />
               <div className="space-y-2">
                 <div className="h-4 w-full max-w-[520px] rounded bg-white/[0.03]" />
                 <div className="h-4 w-full max-w-[400px] rounded bg-white/[0.03]" />
               </div>
-              <div className="flex gap-3 pt-1">
+              <div className="flex flex-wrap gap-3 pt-1">
                 <div className="h-9 w-32 rounded-full bg-white/5" />
                 <div className="h-9 w-24 rounded-full bg-white/[0.03]" />
                 <div className="h-9 w-20 rounded-full bg-white/[0.03]" />
               </div>
             </div>
           </div>
+        </section>
+
+        {/* Terminal showcase */}
+        <section className="mb-14">
+          <div className="h-[260px] rounded-xl border border-white/[0.06] bg-white/[0.02] sm:h-[340px] md:h-[380px]" />
         </section>
 
         {/* Stats bar */}
@@ -41,7 +46,7 @@ export default function Loading() {
         {/* Built with */}
         <section className="mb-14">
           <div className="mb-6 h-3 w-20 rounded bg-white/5" />
-          <div className="grid grid-cols-6 gap-6 md:grid-cols-8">
+          <div className="grid grid-cols-4 gap-5 sm:grid-cols-6 md:grid-cols-8 xl:gap-11">
             {Array.from({ length: 8 }).map((_, i) => (
               <div
                 key={i}

--- a/app/(portfolio)/projects/[slug]/page.tsx
+++ b/app/(portfolio)/projects/[slug]/page.tsx
@@ -63,7 +63,7 @@ export default async function ProjectPage({
     : undefined;
 
   return (
-    <main className="relative z-10 mx-auto max-w-5xl px-4 py-8 md:px-8 md:py-16">
+    <main className="relative z-10 mx-auto max-w-5xl overflow-x-hidden px-4 py-8 md:px-8 md:py-16">
       {/* Ambient accent glow */}
       <div
         className="pointer-events-none fixed top-0 left-1/2 h-[500px] w-[700px] -translate-x-1/2 opacity-[0.06]"
@@ -210,7 +210,7 @@ export default async function ProjectPage({
           <h2 className="mb-6 font-mono text-[11px] tracking-[0.2em] text-white/30 uppercase md:text-[12px]">
             Built with
           </h2>
-          <div className="grid grid-cols-6 gap-[23.45px] md:grid-cols-8 xl:gap-11">
+          <div className="grid grid-cols-4 gap-5 sm:grid-cols-6 md:grid-cols-8 xl:gap-11">
             {project.technologies.map((tech) => (
               <TechIconWrapper key={tech} name={tech as TechIconName} />
             ))}


### PR DESCRIPTION
## Summary
- **Persistent project header**: SubpageHeader moved to layout.tsx — logo + project name persists across sub-page transitions (architecture, features, docs) without reloading. Hidden on overview page which has its own hero.
- **Mobile overflow fixes**: All pages now have `overflow-x-hidden`. ComparisonTable reduced to 360px min-width on mobile. FeatureSectionRow and StepCard flex children get `min-w-0` to prevent content blowout. ArchCodeBlock uses smaller font on mobile.
- **Tech grid**: 4 columns on mobile (was 6, caused right-side overflow), 6 on sm, 8 on md+
- **Loading skeleton**: Matches updated tech grid cols, includes terminal showcase placeholder, responsive title width

## Test plan
- [x] `next build` passes
- [x] All 10 tests pass
- [ ] Mobile: architecture pages no longer overflow horizontally
- [ ] Mobile: features pages no longer overflow
- [ ] Mobile: "Built with" section fits within viewport
- [ ] Sub-page navigation: logo persists when switching tabs
- [ ] Overview page: SubpageHeader hidden (hero section shows instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily layout/styling adjustments plus moving a header into the shared layout; low risk aside from potential unintended spacing/visibility regressions on project pages.
> 
> **Overview**
> Adds a persistent `SubpageHeader` at the `[slug]` layout level so project identity (logo/title + back link) stays visible across mini-site subpages, while the header auto-hides on the overview route.
> 
> Fixes several mobile horizontal overflow issues by applying `overflow-x-hidden` to project pages, tightening responsive sizing for `ComparisonTable`, `ArchCodeBlock`, and flex rows (`min-w-0`), and switching the “Built with” tech grid (and loading skeleton) to fewer columns on small screens with improved skeleton placeholders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 218dfabebab3bd43ee12b7ff92b6e2fa9524e6b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive design across portfolio pages with refined overflow handling and spacing adjustments.
  * Enhanced horizontal scrolling for code blocks and comparison tables on narrow viewports.
  * Refined typography sizing and grid layouts for better mobile experience.

* **Refactor**
  * Improved navigation structure for project sub-pages with conditional header rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->