### PR TITLE
feat: skill detail pages with eval results and install prompts

### DIFF
--- a/app/(golems)/golems/components/SkillsShowcase.tsx
+++ b/app/(golems)/golems/components/SkillsShowcase.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, type ReactNode } from "react";
+import Link from "next/link";
 import golemsStats from "../lib/golems-stats.json";
 import CopyButton from "./CopyButton";
 
@@ -347,7 +348,10 @@ function SkillCard({ skill }: { skill: SkillEntry }) {
   const evalData = getEvalData(skill.name);
 
   return (
-    <div className="group relative rounded-lg border border-[#e5950014] bg-[#14120e]/90 p-4 transition-colors hover:border-[#e5950040]">
+    <Link
+      href={`/golems/skills/${skill.name}`}
+      className="group relative block rounded-lg border border-[#e5950014] bg-[#14120e]/90 p-4 no-underline transition-colors hover:border-[#e5950040]"
+    >
       <div className="mb-2 flex items-center justify-between gap-2">
         <code className="rounded bg-[#e595000f] px-2 py-0.5 font-mono text-xs font-bold text-[#e59500]">
           {skill.command}
@@ -362,7 +366,7 @@ function SkillCard({ skill }: { skill: SkillEntry }) {
       <p className="m-0 text-[0.78rem] leading-relaxed text-[#908575]">
         {skill.description}
       </p>
-    </div>
+    </Link>
   );
 }
 
@@ -438,7 +442,10 @@ export default function SkillsShowcase() {
       : SKILL_CATEGORIES[activeCategory] || [];
 
   return (
-    <section className="relative bg-gradient-to-b from-[#080807] to-[#0c0b0a] py-12 md:py-20">
+    <section
+      id="skills"
+      className="relative bg-gradient-to-b from-[#080807] to-[#0c0b0a] py-12 md:py-20"
+    >
       <div className="absolute top-0 right-0 left-0 h-px bg-gradient-to-r from-transparent via-[#e5950033] to-transparent" />
       <div className="mx-auto max-w-[1100px] px-4 sm:px-6">
         {/* Header */}

--- a/app/(golems)/golems/lib/skills-manifest.json
+++ b/app/(golems)/golems/lib/skills-manifest.json
@@ -1,0 +1,2020 @@
+{
+  "generatedAt": "2026-03-10T08:02:32.756Z",
+  "skillCount": 55,
+  "skills": {
+    "1password": {
+      "name": "1password",
+      "command": "/1password",
+      "description": "Use when managing secrets, credentials, API keys, or vault operations. Supports Environments (Beta) for .env mounting. Covers 1password, secrets, op, vault, migrate, credentials. NOT for: non-secret config (use regular config files).",
+      "category": "Operations",
+      "content": "\n# 1Password Operations\n\n> Secret management skill using 1Password CLI (`op`). Routes to workflows for specific operations.\n\n## Prerequisites Check\n\nRun first:\n```bash\nop account list\n```\n\nIf \"not signed in\" or error: See [workflows/troubleshoot.md](workflows/troubleshoot.md)\n\n---\n\n## 🌟 PREFERRED: 1Password Environments (Beta)\n\n**For .env file management, use 1Password Environments instead of manual CLI migration.**\n\n[Official Docs →](https://developer.1password.com/docs/environments/) | [Full Workflow →](workflows/use-environment.md)\n\n### Key Insight: UI Creation, CLI Access\n\n**Environments are created in the 1Password desktop app UI - not via CLI.** However, once created, CLI tools can still interact with secrets via `op run` and `op inject`.\n\n```\n┌─────────────────────────────────────────────────────────────┐\n│                    ENVIRONMENTS WORKFLOW                     │\n├─────────────────────────────────────────────────────────────┤\n│                                                              │\n│  CREATION (UI Only)           ACCESS (Multiple Options)     │\n│  ─────────────────            ─────────────────────────     │\n│  1Password Desktop App   ──►  • Mounted .env (named pipe)   │\n│  • Developer > Environments   • op run (env vars)           │\n│  • NOT automatable            • op inject (config files)    │\n│                                                              │\n└─────────────────────────────────────────────────────────────┘\n```\n\n### Why Environments?\n\n- **Secrets never on disk** - Named pipe mount, not plaintext file\n- **Real-time sync** - Changes in 1Password instantly available\n- **Team sharing** - Grant access with granular permissions\n- **Multi-device** - Same environment works across all your machines\n\n### Setup Flow (One-Time in Desktop App)\n\n1. **Enable Developer features** → Settings > Developer > Enable Developer Experience\n2. **Create Environment** → Developer > Environments > New Environment\n3. **Import your .env** → Click Import or manually add variables\n4. **Set Mount Destination** → Destinations tab > Local .env file > Choose path\n5. **Authorize** → Confirm when prompted\n\n### Environments vs CLI: When to Use Each\n\n| Scenario | Use Environments | Use CLI (`op run`/`op inject`) |\n|----------|-----------------|-------------------------------|\n| Local development | ✅ Best choice | Works but more setup |\n| CI/CD pipelines | ❌ Can't automate creation | ✅ Service accounts |\n| Team secrets | ✅ Built-in sharing | Manual sync needed |\n| One-time scripts | Overkill | ✅ Quick and easy |\n| Template configs | N/A | ✅ `op inject` with `.tpl` |\n\n### Mounted .env vs op inject\n\n**Mounted .env (Environments):**\n```bash\n# App reads .env.local directly (named pipe, no real file)\nnpm run dev\n# Variables available automatically via dotenv\n```\n\n**op inject (CLI):**\n```bash\n# Template file with secret references (.env.template)\nDATABASE_URL=op://prod/db/url\nAPI_KEY=op://prod/api/key\n\n# Inject at runtime\nop inject -i .env.template -o .env && npm run build\n# Remember to delete .env after!\n```\n\n**op run (CLI):**\n```bash\n# Pass secrets as environment variables\nop run --env-file .env.template -- npm run build\n# No temp file created, secrets in process env only\n```\n\n### Working Example: songscript\n\nThe `songscript` project uses Environments with 9 variables mounted to `.env.local`:\n- Environment contains: `CONVEX_DEPLOY_KEY`, `ANTHROPIC_API_KEY`, etc.\n- Destination: `.env.local` (named pipe, not actual file)\n- Works seamlessly with `bun dev`, `npm run dev`, etc.\n\n### Centralized MCP Secrets (Recommended for Agents)\n\n**Problem:** Each MCP with `op://` refs triggers separate auth prompts.\n\n**Solution:** Centralize all secrets in one file, launch with `op run`.\n\n```\n~/.config/mcp-secrets/\n├── secrets.env          # All op:// refs (one auth loads all)\n└── secrets.env.example  # Template (safe to share)\n```\n\n**Wrapper scripts:**\n```bash\ncursor-secure   # op run --env-file secrets.env -- cursor\nclaude-secure   # op run --env-file secrets.env -- claude\nwith-secrets    # op run --env-file secrets.env -- <any command>\n```\n\n**MCP configs use empty env:**\n```json\n{ \"env\": {} }  // Inherits from parent process\n```\n\n### Example: Golems Configuration\n\nThe golems ecosystem uses Environments for sensitive settings:\n\n1. **Create Environment** in 1Password: `golems`\n2. **Add variables**: `NTFY_TOPIC`, `ANTHROPIC_API_KEY`, `LINEAR_API_KEY`\n3. **Mount to**: `~/.config/golems/.env`\n4. **Usage**: Scripts source the mounted file or use `op run`\n\n```bash\n# Option 1: Source mounted .env\nsource ~/.config/golems/.env\n\n# Option 2: Use op run with template\nop run --env-file ~/.config/golems/.env.template -- bun run start\n```\n\n### Important Limitations (Beta)\n\n| Limitation | Details |\n|------------|---------|\n| **UI-only creation** | Cannot create/edit environments via CLI |\n| **Platform support** | Mac and Linux only (no Windows) |\n| **Max mounts** | 10 enabled .env files per device |\n| **Concurrent reads** | May have conflicts with multiple processes |\n| **Edits in UI only** | Changes to mounted file are lost - edit in 1Password UI |\n| **Beta status** | Feature may change |\n\n### When to Use CLI Instead\n\nUse `op run` or `op inject` ([workflows/migrate-env.md](workflows/migrate-env.md)) when:\n- **CI/CD pipelines** - Need Service Accounts for automated access\n- **Scripted operations** - Creating items programmatically\n- **Template configs** - `.yml.tpl` or `.json.tpl` files with secret refs\n- **Windows** - Environments not available on Windows\n\n---\n\n## Quick Actions\n\n| What you want to do | Workflow |\n|---------------------|----------|\n| Use 1Password Environments | [workflows/use-environment.md](workflows/use-environment.md) |\n| List secrets in vault | [workflows/list-secrets.md](workflows/list-secrets.md) |\n| Add a new secret | [workflows/add-secret.md](workflows/add-secret.md) |\n| Migrate .env to 1Password | [workflows/migrate-env.md](workflows/migrate-env.md) |\n| Migrate MCP config secrets | [workflows/migrate-mcp.md](workflows/migrate-mcp.md) |\n| Fix auth/biometric issues | [workflows/troubleshoot.md](workflows/troubleshoot.md) |\n\n---\n\n## Available Scripts\n\nExecute directly - they handle errors and edge cases:\n\n| Script | Purpose | Usage |\n|--------|---------|-------|\n| `scripts/migrate-env.sh` | Migrate .env with project/service nesting | `bash ~/.claude/commands/1password/scripts/migrate-env.sh .env [--dry-run]` |\n| `scripts/scan-mcp-secrets.sh` | Find API keys in MCP configs | `bash ~/.claude/commands/1password/scripts/scan-mcp-secrets.sh` |\n\n---\n\n## Decision Tree\n\n**Setting up secrets for a project?**\n- PREFERRED: Use Environments (desktop app UI)\n- Use: [workflows/use-environment.md](workflows/use-environment.md)\n\n**Need to find a secret?**\n- Search by name, tag, or vault\n- Use: [workflows/list-secrets.md](workflows/list-secrets.md)\n\n**Adding credentials for a service?**\n- Create new item with password/API key\n- Use: [workflows/add-secret.md](workflows/add-secret.md)\n\n**Have a .env file to secure?**\n- For local dev: Use Environments (UI-based)\n- For CI/CD: Use [workflows/migrate-env.md](workflows/migrate-env.md) or `scripts/migrate-env.sh`\n\n**MCP configs have hardcoded keys?**\n- Scan and migrate to 1Password references\n- Use: [workflows/migrate-mcp.md](workflows/migrate-mcp.md)\n\n**Biometric timeout or auth problems?**\n- Token refresh, re-auth, session issues\n- Use: [workflows/troubleshoot.md](workflows/troubleshoot.md)\n\n---\n\n## Service Auto-Detection\n\nWhen migrating secrets, keys are auto-categorized:\n\n| Key prefix | Service folder |\n|------------|----------------|\n| `ANTHROPIC_*` | anthropic/ |\n| `OPENAI_*` | openai/ |\n| `SUPABASE_*` | supabase/ |\n| `DATABASE_*`, `DB_*` | db/ |\n| `STRIPE_*` | stripe/ |\n| `AWS_*` | aws/ |\n| `GITHUB_*` | github/ |\n| Other | misc/ |\n\nItem path format: `{project}/{service}/{key}`\n\n---\n\n## Vault Organization\n\n### Vault Types\n\n| Vault | Purpose | Example Items |\n|-------|---------|---------------|\n| `development` | Global dev tools | context7, github CLI tokens |\n| `Private` | Personal secrets | SSH keys, personal accounts |\n| `{project}` | Project-specific | linear API key, deploy keys |\n| `Shared` | Team secrets | Shared service accounts |\n\n### Creating Vaults\n\n```bash\n# Create project vault\nop vault create \"myproject\" --description \"MyProject secrets\" --icon buildings\n\n# Create tools vault\nop vault create \"development\" --description \"Global dev tools\" --icon gears\n```\n\n### Where to Put Secrets\n\n**Global dev tools** → `development` vault:\n- context7, MCP tools, IDE plugins\n- Used across all projects\n\n**Project-specific** → `{project}` vault:\n- Linear API keys (per workspace)\n- Deploy keys, CI/CD tokens\n- Database credentials\n\n**Personal** → `Private` vault:\n- SSH keys, personal tokens\n- Accounts only you use\n\n### Tagging Strategy\n\nUse tags for cross-vault searching and organization:\n\n```bash\n# Add tags when creating\nop item create --vault development --category \"API Credential\" \\\n  --title \"context7\" 'API_KEY[password]=xxx' \\\n  --tags \"dev-tools,mcp,documentation\"\n\n# Search by tag across all vaults\nop item list --tags \"mcp\"\nop item list --tags \"dev-tools\"\n```\n\n**Recommended tags:**\n| Tag | Use for |\n|-----|---------|\n| `dev-tools` | Development utilities |\n| `mcp` | MCP server credentials |\n| `ci-cd` | CI/CD pipeline secrets |\n| `api-key` | Third-party API keys |\n| `deploy` | Deployment credentials |\n| `{project}` | Project name for filtering |\n\n### Reference Format\n\n```bash\n# Vault/Item/Field\nop://development/context7/API_KEY\nop://myproject/linear/API_KEY\nop://Private/github/token\n```\n\n---\n\n## Safety Rules\n\n1. **Never log secret values** - Only show masked versions\n2. **Dry-run first** - Use `--dry-run` before actual migration\n3. **Don't delete .env files** - Migration creates .env.template alongside\n4. **Verify vault access** - Run `op vault list` before operations\n5. **Backup before bulk changes** - Export vault if doing large migrations\n",
+      "evalCount": 3,
+      "assertionCount": 10,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 3,
+          "assertions": [
+            "uses-op-cli-for-secrets",
+            "targets-correct-vault",
+            "provides-value-directly"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 4,
+          "assertions": [
+            "uses-dry-run-first",
+            "creates-env-template",
+            "does-not-delete-original-env",
+            "auto-categorizes-by-prefix"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "recommends-environments-for-local-dev",
+            "notes-ui-only-creation",
+            "explains-named-pipe-benefit"
+          ]
+        }
+      ],
+      "workflows": [
+        "add-secret",
+        "list-secrets",
+        "migrate-env",
+        "migrate-mcp",
+        "troubleshoot",
+        "use-environment"
+      ],
+      "lastModified": "2026-03-06"
+    },
+    "archive": {
+      "name": "archive",
+      "command": "/archive",
+      "description": "Use when planning a sprint transition, archiving completed work, or resetting the PRD for a fresh start. Archives completed PRD stories to docs.local/. Covers archive, cleanup, sprint transition, reset PRD. NOT for: deleting stories mid-sprint (use prd-manager), viewing PRD status (use ralph-status).",
+      "category": "Quality",
+      "content": "\n# Archive PRD Stories\n\n> Archive completed stories to `docs.local/prd-archive/` with full history preservation. Optionally reset the working PRD for a fresh start.\n\n## Available Scripts\n\nRun these directly - standalone, no ralph.zsh dependency:\n\n| Script | Purpose | Usage |\n|--------|---------|-------|\n| `scripts/archive-snapshot.sh` | Create archive snapshot | `bash ~/.claude/commands/archive/scripts/archive-snapshot.sh` |\n| `scripts/cleanup-completed.sh` | Archive + remove completed | `bash ~/.claude/commands/archive/scripts/cleanup-completed.sh` |\n\n---\n\n## Quick Actions\n\n| What you want to do | Workflow |\n|---------------------|----------|\n| Archive current PRD state (snapshot) | [workflows/archive-snapshot.md](workflows/archive-snapshot.md) |\n| Remove completed stories (cleanup) | [workflows/cleanup-completed.md](workflows/cleanup-completed.md) |\n\n---\n\n## What Gets Archived\n\nEach archive creates a timestamped directory:\n\n```\ndocs.local/prd-archive/20260123-153000/\n├── index.json           # PRD index at time of archive\n├── stories/             # All story files (completed + pending)\n│   ├── US-001.json\n│   ├── US-002.json\n│   └── ...\n└── progress.txt         # Ralph progress log\n```\n\n---\n\n## Cleanup Behavior\n\nWhen cleanup is triggered (via `--clean` or confirming prompt):\n\n1. **Completed stories deleted** - All `*.json` files where `passes=true`\n2. **Index reset** - Stats reset, pending array rebuilt from remaining stories\n3. **Progress cleared** - `progress.txt` replaced with fresh start header\n\n**History is always preserved** - The archive contains full state before cleanup.\n\n---\n\n## Safety Notes\n\n1. **Always archives first** - Cleanup only happens after successful archive\n2. **Blocked stories preserved** - Stories in blocked array are kept\n3. **Pending stories preserved** - Only completed (passes=true) stories removed\n4. **Reversible** - Full state available in `docs.local/prd-archive/`\n",
+      "evalCount": 2,
+      "assertionCount": 8,
+      "hasFixtures": true,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 5,
+          "assertions": [
+            "creates-timestamped-archive-directory",
+            "archives-before-cleanup",
+            "preserves-pending-and-blocked",
+            "resets-prd-index-after-cleanup",
+            "uses-archive-scripts"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "creates-snapshot-without-cleanup",
+            "archive-contains-full-state",
+            "no-stories-deleted"
+          ]
+        }
+      ],
+      "workflows": [
+        "archive-snapshot",
+        "cleanup-completed"
+      ],
+      "lastModified": "2026-03-06"
+    },
+    "brainlayer": {
+      "name": "brainlayer",
+      "command": "/brainlayer",
+      "description": "Use when brain_search/brain_store/brain_recall fail, when you need BrainLayer CLI syntax for indexing/enrichment, or when checking storage stats and DB paths. NOT for basic MCP tool usage (that works automatically).",
+      "category": "Research & Context",
+      "content": "\n# BrainLayer — Knowledge Pipeline\n\n> **External repo:** github.com/{GITHUB_USER}/brainlayer\n> Formerly \"Zikaron\". CLI: `brainlayer`. MCP tools: `brain_search`, `brain_store`, `brain_recall`.\n\nBrainLayer indexes Claude Code conversation history into a searchable vector database. Query past solutions, code patterns, and debugging sessions.\n\n## MCP Tools (3 available)\n\n| Tool | What It Does |\n|------|-------------|\n| `brain_search` | Semantic search across past conversations and knowledge |\n| `brain_store` | Persistently store memories (auto-type, auto-importance) |\n| `brain_recall` | Proactive context retrieval by file, topic, or current state |\n\n*Old `brainlayer_*` names still work as backward-compat aliases.*\n\n## CLI Quick Reference\n\n```bash\n# Search past conversations\nbrainlayer search \"how did I implement authentication\"\nbrainlayer search \"error handling\" --project golems\n\n# Index conversations\nbrainlayer index\nbrainlayer index -p project-name\n\n# Run enrichment (local LLM metadata extraction)\nbrainlayer enrich\n\n# Stats\nbrainlayer stats\n\n# Interactive dashboard\nbrainlayer dashboard\n```\n\n## MCP Config\n\n```json\n{\n  \"mcpServers\": {\n    \"brainlayer\": {\n      \"command\": \"brainlayer-mcp\"\n    }\n  }\n}\n```\n\n## Storage\n\n```text\n~/.local/share/brainlayer/\n├── brainlayer.db    # sqlite-vec database (vectors + metadata, ~1.4GB)\n└── prompts/         # Deduplicated system prompts\n```\n\n## When to Use\n\n- **Finding past solutions**: \"How did I handle that API rate limiting before?\"\n- **Debugging patterns**: \"What error messages have I seen with this library?\"\n- **Code reuse**: \"Find my previous implementation of pagination\"\n- **File history**: \"What sessions touched this file?\"\n- **Regression detection**: \"What changed since this file last worked?\"\n",
+      "evalCount": 3,
+      "assertionCount": 9,
+      "hasFixtures": true,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 3,
+          "assertions": [
+            "provides-cli-commands-not-mcp",
+            "mentions-db-path",
+            "mentions-enrichment-option"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "provides-exact-mcp-config-json",
+            "uses-brainlayer-mcp-binary-name",
+            "mentions-three-mcp-tools"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "checks-local-share-path",
+            "identifies-sqlite-vec-db",
+            "uses-stats-command-or-du"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-10"
+    },
+    "brave": {
+      "name": "brave",
+      "command": "/brave",
+      "description": "Use as fallback browser automation when Claude-in-Chrome MCP is unavailable. Covers browser control, navigation, screenshots, clicking, typing. NOT for: headless testing (use Playwright). Claude Code users should prefer MCP first.",
+      "category": "Domain",
+      "content": "\n# Brave Browser Management (v2.2.0)\n\n> Browser automation via brave-manager CLI. **Claude Code should prefer Claude-in-Chrome MCP** - use brave-manager as fallback.\n\n## Prerequisites Check\n\n**1. Check brave-manager installed:**\n```bash\nwhich brave-manager || echo \"Not installed\"\n```\n\n**2. Launch Brave with debug port enabled:**\n```bash\n# Close Brave completely first, then:\nopen -a 'Brave Browser' --args --remote-debugging-port=9222\n```\n\nIf Brave is already running without the debug flag, quit it completely and relaunch.\n\n**3. Verify connection:**\n```bash\nbrave-manager tabs\n```\n\nIf not installed or connection issues: See [workflows/debugging.md](workflows/debugging.md)\n\n---\n\n## Quick Actions\n\n| What you want to do | Workflow |\n|---------------------|----------|\n| Navigate, switch tabs, page history | [workflows/navigation.md](workflows/navigation.md) |\n| Get element IDs, take screenshots, see errors | [workflows/inspection.md](workflows/inspection.md) |\n| Click, type, scroll, drag elements | [workflows/interaction.md](workflows/interaction.md) |\n| Run JS eval, verify state, debug | [workflows/debugging.md](workflows/debugging.md) |\n\n---\n\n## Core Concept: ID-Based Interaction\n\n**Always inspect first!** Before clicking or typing:\n\n```bash\nbrave-manager inspect\n```\n\nThis:\n1. Numbers all interactive elements on the page\n2. Draws red labels for visual reference\n3. Returns the ID mapping for use with click/type/hover\n\n---\n\n## Decision Tree\n\n**Need to navigate?**\n- Open URL, switch tabs, go back/forward\n- Use: [workflows/navigation.md](workflows/navigation.md)\n\n**Need to see the page state?**\n- Inspect elements, take screenshots, check errors\n- Use: [workflows/inspection.md](workflows/inspection.md)\n\n**Need to interact with elements?**\n- Click buttons, fill forms, scroll, drag\n- Use: [workflows/interaction.md](workflows/interaction.md)\n\n**Need to verify/debug?**\n- Run JavaScript, check localStorage, debug state\n- Use: [workflows/debugging.md](workflows/debugging.md)\n\n---\n\n## Command Quick Reference\n\n| Command | Purpose |\n|---------|---------|\n| `tabs` | List all open tabs |\n| `switch <index>` | Focus specific tab |\n| `navigate <url>` | Go to URL |\n| `back` / `forward` | Browser history |\n| `inspect` | Get element IDs (REQUIRED before interaction) |\n| `screenshot` | Save visual state |\n| `errors` | Last 5 network/console errors |\n| `click <id>` | Click element |\n| `type <id> \"text\"` | Type into element |\n| `hover <id>` | Hover element |\n| `scroll <up\\|down\\|id>` | Scroll page or to element |\n| `press <key>` | Press keyboard key |\n| `drag <from> <to>` | Drag between elements |\n| `eval \"code\"` | Run JavaScript |\n\n---\n\n## Safety Rules\n\n1. **Always inspect first** - Element IDs change between page loads\n2. **Check errors** - Use `errors` before reproducing bugs\n3. **Screenshot often** - Visual verification prevents assumptions\n4. **Scroll before click** - Off-screen elements may not be clickable\n",
+      "evalCount": 3,
+      "assertionCount": 13,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 5,
+          "assertions": [
+            "prerequisites-check-before-action",
+            "inspect-before-click",
+            "correct-command-sequence",
+            "uses-brave-manager-cli",
+            "debug-port-launch"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "refuses-blind-click",
+            "warns-about-stale-ids",
+            "connection-verification"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 5,
+          "assertions": [
+            "checks-errors-command",
+            "screenshot-for-verification",
+            "uses-eval-for-debugging",
+            "scroll-before-interact",
+            "no-destructive-actions-without-confirmation"
+          ]
+        }
+      ],
+      "workflows": [
+        "debugging",
+        "inspection",
+        "interaction",
+        "navigation"
+      ],
+      "lastModified": "2026-03-01"
+    },
+    "catchup": {
+      "name": "catchup",
+      "command": "/catchup",
+      "description": "Use when returning to work after any break — auto-detects depth. Short break (hours): reads only uncommitted changes. Long break (48h+) or context overflow: reads all branch changes vs main. Covers catchup, context recovery, refresh, rebuild understanding. NOT for: mid-task exploration (use Read/Grep directly).",
+      "category": "Research & Context",
+      "content": "\n# Skill: Catchup (Context Recovery)\n\n> Auto-detects break length and adjusts depth. Short break = uncommitted changes only. Long break = full branch diff vs main.\n\n## When to Use\n\n- Returning after ANY break (hours or days)\n- Context window overflow — need to rebuild understanding\n- Before committing — review what's staged\n- Reviewing what's been done on a feature branch\n\n## Auto-Detect Mode\n\n**Check both signals to pick the right mode:**\n\n```bash\n# 1. Check uncommitted changes\ngit status --short\n\n# 2. Check branch commit count\ngit log --oneline main...HEAD 2>/dev/null | wc -l\n```\n\n| Uncommitted changes? | Branch commits? | Mode |\n|---------------------|-----------------|------|\n| Yes | Few (0-3) | **Quick** — read uncommitted only |\n| No | Many (4+) | **Full** — read all branch changes |\n| Yes | Many (4+) | **Full** — read everything |\n| No | None | **Nothing to catch up on** |\n\nUser can override: `/catchup quick` or `/catchup full`\n\n---\n\n## Quick Mode (short break, uncommitted changes)\n\n### Step 1: Get Status\n\n```bash\ngit status --short\n```\n\nStatus codes:\n- `M ` — Modified (staged)\n- ` M` — Modified (unstaged)\n- `MM` — Modified (both)\n- `A ` — Added (staged)\n- `??` — Untracked\n\n### Step 2: Read Modified Files\n\nRead only files with `M` status. Skip untracked (`??`) unless relevant.\n\n### Step 3: Quick Summary\n\n- Files currently being edited\n- What changes are in progress\n- Ready to continue or need clarification\n\n---\n\n## Full Mode (long break, full branch context)\n\n### Step 1: Get Changed Files\n\n```bash\ngit diff --name-only main...HEAD\n```\n\n### Step 2: Read All Changed Files\n\nRead in dependency order:\n1. Schema/database files (`schema.ts`, `convex/`, `prisma/`)\n2. Config files (`package.json`, `tsconfig.json`, `.env.example`)\n3. Server/API files (`actions/`, `api/`, `server/`)\n4. Components/UI files (`components/`, `app/`)\n5. Tests (`tests/`, `*.test.ts`)\n\n### Step 3: Full Summary\n\n- What feature/fix is being worked on\n- Current state of implementation\n- What appears to be left to do\n\n---\n\n## Tips\n\n- If full mode shows 50+ files, start with quick mode first\n- Check `git log main...HEAD --oneline` for commit history context\n- Look for TODO/FIXME comments to understand remaining work\n- Combine with `git diff` to see actual line changes\n",
+      "evalCount": 3,
+      "assertionCount": 10,
+      "hasFixtures": true,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 3,
+          "assertions": [
+            "auto-detects-mode",
+            "reads-relevant-files",
+            "provides-summary"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 4,
+          "assertions": [
+            "uses-full-mode",
+            "reads-in-dependency-order",
+            "checks-commit-history",
+            "identifies-remaining-work"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "uses-quick-mode",
+            "reads-only-modified",
+            "brief-summary"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-07"
+    },
+    "catchup-recent": {
+      "name": "catchup-recent",
+      "command": "/catchup-recent",
+      "description": "Use when taking a short break (hours, not days) and need quick refresh. Reads only uncommitted changes (staged and unstaged). Covers quick catchup, refresh. NOT for: long breaks or full branch review (use catchup instead).",
+      "category": "Other",
+      "content": "\n# Skill: Catchup Recent (Quick Context Recovery)\n\n> Use for quick catch-up when you only need to see what's currently being worked on. Reads only modified/unstaged files, not the entire branch history.\n\n## When to Use\n\n- Short break from work (few hours)\n- Want to see only uncommitted changes\n- Quick refresh before continuing\n- Before committing - review what will be staged\n\n## Instructions\n\n### Step 1: Get Status\n\nRun:\n```bash\ngit status --short\n```\n\nThis shows:\n- `M ` - Modified (staged)\n- ` M` - Modified (unstaged)\n- `MM` - Modified (both staged and unstaged changes)\n- `A ` - Added (staged)\n- `??` - Untracked\n\n### Step 2: Read Modified Files\n\nRead only files with `M` status (modified). Skip untracked (`??`) unless they appear relevant.\n\nFocus on files that are:\n- Currently being edited (unstaged `M`)\n- Already staged for commit (staged `M` or `A`)\n\n### Step 3: Quick Summary\n\nAfter reading, provide a brief summary:\n- Files currently being edited\n- What changes appear to be in progress\n- Ready to continue or need clarification\n\n## Example Session\n\n```\nUser: /catchup-recent\n\nClaude: Let me see what's currently being worked on.\n\n[Runs: git status --short]\n\n M src/components/TaskItem.tsx\n M src/components/TaskList.tsx\nM  src/convex/tasks.ts\n?? src/components/DeleteModal.tsx\n\nFound 3 modified files and 1 untracked.\n\n[Reads the 3 modified files]\n\n**Quick Summary:**\n- TaskItem.tsx: Adding delete button with onClick handler\n- TaskList.tsx: Passing onDelete prop to TaskItem\n- tasks.ts: Delete mutation already implemented (staged)\n- DeleteModal.tsx: New untracked file (appears to be WIP)\n\n**Current work:** Implementing delete functionality for tasks\n**Status:** Delete mutation ready, UI integration in progress\n\nReady to continue?\n```\n\n## Difference from /catchup\n\n| Catchup | Catchup-Recent |\n|---------|---------------|\n| All files changed in branch | Only uncommitted changes |\n| `git diff --name-only main...HEAD` | `git status --short` |\n| Full context recovery | Quick refresh |\n| After long absence | After short break |\n\n## Tips\n\n- Combine with `git diff` to see actual line changes if needed\n- For full branch context, use `/catchup` instead\n- If status shows many files, consider committing in progress work first\n",
+      "evalCount": 0,
+      "assertionCount": 0,
+      "hasFixtures": false,
+      "evals": [],
+      "workflows": [],
+      "lastModified": "2026-03-02"
+    },
+    "cli-agents": {
+      "name": "cli-agents",
+      "command": "/cli-agents",
+      "description": "Run external CLI agents (Gemini, Cursor, Codex, Kiro, Claude) via cmux panes. Workers split in current workspace. Audits/research open in a new named workspace. All agents are interactive and visible.",
+      "category": "Domain",
+      "content": "\n# CLI Agents Skill\n\nExternal AI agents spawned as interactive cmux panes. Two patterns based on intent:\n\n| Intent | Where | Why |\n|--------|-------|-----|\n| **Worker** (code, implementation, collab) | Split in current workspace | Visible side-by-side, easy to monitor |\n| **Audit/Research** (read-only, analysis) | New workspace, named | Doesn't clutter working view, find in sidebar |\n\n## Spawning Workers (split in current workspace)\n\n```bash\n# Split right, label it, send the agent command\nSURFACE=$(cmux new-split right | awk '{print $2}')\ncmux rename-tab --surface \"$SURFACE\" \"Agent Label\"\ncmux send --surface \"$SURFACE\" \"cd ~/Gits/TARGET_REPO && AGENT_CMD\"\ncmux send-key --surface \"$SURFACE\" Return\n```\n\n### Agent commands\n\n```bash\n# Claude (use repoGolem function or raw CLI)\n\"claude -s 'your prompt here'\"           # -s = dangerously-skip-permissions\n\n# Cursor (work mode — modifies files)\n\"cursor agent -p --model gpt-5.2-codex-xhigh --trust 'your prompt here'\"\n\n# Codex (work mode)\n\"codex --full-auto 'your prompt here'\"\n\n# Gemini (text-only, good for research)\n\"gemini 'your prompt here'\"\n\n# Kiro (text-only)\n\"kiro-cli chat --no-interactive 'your prompt here'\"\n```\n\n### Example: 3 parallel workers\n\n```bash\n# Launch sequentially (1Password biometric needs ~2s between each)\nfor repo in brainlayer golems voicelayer; do\n  SURFACE=$(cmux new-split right | awk '{print $2}')\n  cmux rename-tab --surface \"$SURFACE\" \"$repo\"\n  cmux send --surface \"$SURFACE\" \"cd ~/Gits/$repo && claude -s 'your task here'\"\n  cmux send-key --surface \"$SURFACE\" Return\n  sleep 3  # Wait for Touch ID\ndone\n```\n\n## Spawning Audits/Research (new workspace)\n\n```bash\n# New workspace so it doesn't clutter your working view\ncmux new-workspace\nSURFACE=$(cmux list-pane-surfaces --pane \"$(cmux list-panes | tail -1 | grep -oE 'pane:[0-9]+')\" | grep -oE 'surface:[0-9]+' | head -1)\ncmux rename-tab --surface \"$SURFACE\" \"Audit: reponame\"\ncmux send --surface \"$SURFACE\" \"cd ~/Gits/TARGET_REPO && AGENT_CMD\"\ncmux send-key --surface \"$SURFACE\" Return\n```\n\n### Example: Cursor audit in separate workspace\n\n```bash\ncmux new-workspace\n# Get the new surface\nSURFACE=$(cmux list-pane-surfaces --pane \"$(cmux list-panes | tail -1 | grep -oE 'pane:[0-9]+')\" | grep -oE 'surface:[0-9]+' | head -1)\ncmux rename-tab --surface \"$SURFACE\" \"Audit: golems\"\ncmux send --surface \"$SURFACE\" \"cd ~/Gits/golems && cursor agent -p --output-format text --model gpt-5.2-codex-xhigh --trust 'Audit recent changes. Check: code quality, bugs, missing tests, security, dead code. Be harsh.'\"\ncmux send-key --surface \"$SURFACE\" Return\n```\n\n### Example: Multi-agent audit wave (3 perspectives)\n\n```bash\nfor i in 1 2 3; do\n  cmux new-workspace\n  SURFACE=$(cmux list-pane-surfaces --pane \"$(cmux list-panes | tail -1 | grep -oE 'pane:[0-9]+')\" | grep -oE 'surface:[0-9]+' | head -1)\n  cmux rename-tab --surface \"$SURFACE\" \"Audit $i: golems\"\n  cmux send --surface \"$SURFACE\" \"cd ~/Gits/golems && cursor agent -p --output-format text --model gpt-5.2-codex-xhigh --trust 'ANGLE $i PROMPT'\"\n  cmux send-key --surface \"$SURFACE\" Return\n  sleep 3\ndone\n```\n\n## Monitoring Agents\n\n```bash\n# Check what an agent is doing\ncmux read-screen --surface surface:N --lines 8\n\n# Check all agents at once\nbash ~/.claude/commands/cli-agents/scripts/agent-status.sh\n\n# Send follow-up to an agent\ncmux send --surface surface:N \"additional instructions\"\ncmux send-key --surface surface:N Return\n```\n\n## Agent Selection Guide\n\n| Task | Agent | Model | Notes |\n|------|-------|-------|-------|\n| Plan auditing, perspectives | cursor | GPT-5.2 Codex | Sonnet-tier tasks, don't waste Opus |\n| Code review, codebase analysis | cursor | GPT-5.2 Codex | Has @codebase access |\n| Quick research, comparisons | gemini | Gemini 2.5 Pro | Free, 1K/day |\n| Parallel implementation | cursor/codex | varies | Work mode, modifies files |\n| Collab agent (writes to collab file) | claude -s | Opus/Sonnet | Use Sonnet for audit collabs |\n| Deep reasoning, architecture | claude -s | Opus | Only when needed |\n\n## Cursor Bug Bot (GitHub PR Reviews)\n\n```bash\n# Trigger inline PR review on GitHub\ngh pr comment <N> --body \"cursor review\"\n```\n\n## Rules\n\n1. **Workers = split, Audits = new workspace** — don't mix\n2. **Launch sequentially** — 1Password biometric needs ~2-3s between spawns\n3. **Use Sonnet for audits** — don't waste Opus on read-only analysis\n4. **Name workspaces clearly** — \"Audit: reponame\", \"Research: topic\"\n5. **Monitor with read-screen** — don't assume agents finished\n6. **Verify cursor findings** — cursor can't always tell if files are git-tracked. Check with `git ls-files` before acting.\n",
+      "evalCount": 3,
+      "assertionCount": 13,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 6,
+          "assertions": [
+            "audits-use-new-workspace",
+            "correct-cursor-cli-syntax",
+            "workspace-naming",
+            "correct-repo-targeting",
+            "send-then-send-key-pattern",
+            "no-claude-subagents"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 4,
+          "assertions": [
+            "workers-use-splits-not-workspaces",
+            "sequential-launch-with-sleep",
+            "work-mode-no-text-output",
+            "labels-each-split"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "verifies-before-acting",
+            "mentions-false-positive-risk",
+            "no-premature-credential-rotation"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-06"
+    },
+    "cmux": {
+      "name": "cmux",
+      "command": "/cmux",
+      "description": "Use when running inside cmux terminal to control panes, splits, browser, sidebar, and coordinate multi-agent workflows. Covers split panes, notifications, browser automation, agent-to-agent messaging via cmux send. NOT for: regular terminal operations (use Bash), non-cmux sessions.",
+      "category": "Operations",
+      "content": "\n# cmux Terminal Control\n\n> Teach agents to drive cmux: split panes, notify, open browser, coordinate with other agents.\n\n## Detect cmux\n\nAlways check first — skip gracefully if not in cmux:\n\n```bash\nif ! command -v cmux &>/dev/null || ! cmux identify --json &>/dev/null; then\n  echo \"Not in cmux — skipping cmux operations\"\n  exit 0\nfi\n```\n\n## Self-Identification\n\n```bash\n# Get your own location\ncmux identify --json\n# → { \"surface_ref\": \"surface:4\", \"pane_ref\": \"pane:5\", \"workspace_ref\": \"workspace:2\" }\n```\n\n## Identify & Navigate\n\n```bash\n# Get your current surface/pane/workspace refs\ncmux identify\n\n# List all workspaces\ncmux list-workspaces\n\n# List panes in current workspace\ncmux list-panes\n\n# List surfaces (tabs) in a pane\ncmux list-pane-surfaces --pane pane:1\n```\n\n## Splits (Most Common)\n\n```bash\n# Split current surface left/right/up/down\ncmux new-split right    # adds a right split in current workspace\ncmux new-split down\n\n# Get the new surface ref after splitting\ncmux list-pane-surfaces --pane pane:1\n\n# Close a surface\ncmux close-surface --surface surface:5\n```\n\n## Workspaces (New Tabs)\n\n```bash\n# New workspace (new sidebar tab)\ncmux new-workspace\n\n# Focus a workspace\ncmux focus-pane --pane pane:2\n\n# Rename the tab label\ncmux rename-tab --surface surface:3 \"🤖 Agent Name\"\n```\n\n## Send Commands to Panes\n\n```bash\n# Send text (as if typed) to a surface\ncmux send --surface surface:3 \"cd ~/Gits/golems && claude 'prompt here'\\n\"\n\n# Send a single key\ncmux send-key --surface surface:3 Return\n\n# Note: \\n at end of send = auto-press Enter to run\n```\n\n## Notifications\n\n```bash\n# Notification ring (tab lights up in sidebar)\ncmux notify \"Title\" \"Body text\"\n\n# Workspace-action for custom sidebar label\ncmux workspace-action --action set-title --title \"🤖 orcClaude\"\n```\n\n## In-App Browser\n\n```bash\n# Open browser pane (splits alongside terminal)\ncmux new-pane --type browser --direction right --url \"http://localhost:3000\"\n\n# Navigate existing browser surface\ncmux browser navigate \"http://localhost:3000/new-page\"\n\n# Browser tab management\ncmux browser tab new \"https://docs.example.com\"\ncmux browser tab list\n```\n\n## Agent-to-Agent Messaging\n\n```bash\n# Send text to another agent's surface\ncmux send --surface surface:6 \"STATUS: done with auth module, ready for review\"\n\n# Envelope format for deterministic messaging:\n# [FROM=surface:A TO=surface:B TYPE=TYPE] key=val\ncmux send --surface surface:6 \\\n  \"[FROM=surface:1 TO=surface:6 TYPE=TASK] repo=golems task=fix-tests\"\n```\n\n## Parallel Agent Fan-out Pattern\n\n```bash\n# 1. Identify self\nMY_SURFACE=$(cmux identify | jq -r '.caller.surface_ref')\nMY_WS=$(cmux identify | jq -r '.caller.workspace_ref')\n\n# 2. Spawn 3 splits, each running claude on different repos\nfor repo in brainlayer golems voicelayer; do\n  NEW_SURFACE=$(cmux new-split right --workspace \"$MY_WS\" | awk '{print $2}')\n  cmux rename-tab --surface \"$NEW_SURFACE\" \"🤖 $repo\"\n  sleep 0.5\n  cmux send --surface \"$NEW_SURFACE\" \"cd ~/Gits/$repo && claude 'your task here'\\n\"\ndone\n```\n\n## golem-terminal Integration Note\n\nThese cmux patterns are the reference implementation for golem-terminal's UDS API. The golem-terminal equivalents:\n\n| cmux | golem-terminal |\n|------|---------------|\n| `cmux split` | `orchestrate.py split <slot>` |\n| `cmux notify` | HTTP POST localhost:3847/notify |\n| `cmux sidebar set` | UDS `status` command |\n| `cmux send` | UDS `send_input` command |\n| `cmux open-browser` | Built into sidebar pane |\n\n## Rules\n\n1. **Always detect cmux first** — don't assume you're in cmux\n2. **Use envelope format** for agent messages — prevents cross-pane confusion\n3. **Set sidebar status** at task start + end — gives user visibility\n4. **Notify on completion** — ring is better than polling\n5. **Don't spawn too many panes** — 4-6 max, cmux gets crowded\n",
+      "evalCount": 3,
+      "assertionCount": 8,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 3,
+          "assertions": [
+            "uses-new-pane-not-new-split",
+            "extracts-surface-id",
+            "uses-send-for-text-send-key-for-special"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "send-for-text-not-send-key",
+            "send-key-for-return",
+            "correct-surface-targeting"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 2,
+          "assertions": [
+            "rejects-send-key-for-text",
+            "does-not-use-individual-character-send-key"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-06"
+    },
+    "cmux-agents": {
+      "name": "cmux-agents",
+      "command": "/cmux-agents",
+      "description": "Spawn AI agents in cmux panes — Claude workers as splits, audits/research as surfaces. Covers Claude, Cursor, Gemini, Codex, Kiro, T3 Code. Includes monitoring, prompt delivery, and collab patterns. Use this skill whenever the user mentions cmux agents, terminal agents, split agents, multi-agent orchestration, or wants to spawn AI workers in visible terminal panes.",
+      "category": "Operations",
+      "content": "\n# cmux-agents\n\nSpawn and manage AI agents in cmux terminal panes.\n\n## First-Time Setup\n\n**Check for `~/.golems/config.yaml`.** This is the golems ecosystem config — it has workspace path, tool paths, and feature flags.\n\nIf `~/.golems/config.yaml` does NOT exist, this is a first-time user. Before doing anything else:\n\n1. **Auto-detect available AI CLIs:**\n   ```bash\n   which claude >/dev/null 2>&1 && echo \"claude: $(which claude)\" || echo \"claude: NOT FOUND\"\n   which cursor >/dev/null 2>&1 && echo \"cursor: $(which cursor)\" || echo \"cursor: NOT FOUND\"\n   which gemini >/dev/null 2>&1 && echo \"gemini: $(which gemini)\" || echo \"gemini: NOT FOUND\"\n   which codex >/dev/null 2>&1 && echo \"codex: $(which codex)\" || echo \"codex: NOT FOUND\"\n   which kiro-cli >/dev/null 2>&1 && echo \"kiro: $(which kiro-cli)\" || echo \"kiro: NOT FOUND\"\n   ```\n\n2. **Ask the user:**\n   - Where do your repos live? (e.g., `~/Projects`, `~/Code`, `~/dev`)\n   - Do you have custom Claude launchers (shell functions wrapping `claude`)? If so, what are they called?\n\n3. **Write `~/.golems/config.yaml`:**\n   ```yaml\n   # Golems Configuration\n   reposPath: \"~/Projects\"    # User's workspace root\n   tools:\n     claude: \"/path/to/claude\"\n     cursor: \"/path/to/cursor\"   # omit if not installed\n     gemini: \"/path/to/gemini\"   # omit if not installed\n   ```\n\n4. **Confirm and proceed** with the user's original request.\n\nIf `~/.golems/config.yaml` EXISTS, read it and use:\n- `reposPath` → replaces `$WORKSPACE` in all commands below\n- `tools.*` → determines which agents are available and their exact paths\n- Only offer agents whose tools are listed in the config\n\n## CRITICAL: Surface Discovery First\n\n**BEFORE spawning or interacting with any surface, ALWAYS discover your environment:**\n\n```bash\n# 1. Where am I?\ncmux list-workspaces                                    # Shows all workspaces, * = current\ncmux list-panes                                         # Panes in current workspace\ncmux list-pane-surfaces --pane pane:N                    # Surfaces in a pane, * = selected\n\n# 2. Which surface is ME?\n# YOUR surface is where this Claude session is running.\n# NEVER cmux read-screen your own surface — you'll see yourself reading yourself.\n# If unsure, check: the surface marked [selected] in YOUR pane is likely you.\n\n# 3. Cross-workspace: ALWAYS pass --workspace\ncmux list-panes --workspace workspace:N\ncmux read-screen --surface surface:N --workspace workspace:N --lines 15\ncmux send --surface surface:N --workspace workspace:N \"command\"\n```\n\n**Common mistake:** Reading `surface:27` thinking it's another agent, but it's YOU. Always verify by listing surfaces first.\n\n## Agent Layout\n\n| Role | Where | Why |\n|------|-------|-----|\n| **Workers** (Claude, implementation, collab) | `cmux new-split right` in current workspace | Visible side-by-side with you |\n| **Audits/research** (Cursor, Gemini, read-only) | `cmux new-split down` or separate workspace | Accessible but not cluttering |\n\n## CLI Syntax (VERIFIED — use exactly as shown)\n\n| Agent | Command | Notes |\n|-------|---------|-------|\n| **Claude** (with custom launcher) | User's configured launcher (e.g., `myLauncher -s`) | If user has custom launchers in their config, use those. |\n| **Claude** (standard) | `claude --dangerously-skip-permissions` | Default — works everywhere. |\n| **Cursor** (audit, read-only) | `cursor agent --output-format text --model \"gpt-5.3-codex-xhigh\" \"PROMPT\"` | `--output-format text` for audits. |\n| **Cursor** (work, edits files) | `cursor agent --model \"gpt-5.3-codex-xhigh\" \"PROMPT\"` | Omit `--output-format text` for work mode. |\n| **Gemini** | `gemini \"PROMPT\"` | Global binary. Free tier, 2 RPM. 1M context. |\n| **Codex** | `codex \"PROMPT\"` | Global binary. |\n| **Kiro** | `kiro-cli \"PROMPT\"` | Text-only. |\n\n**WRONG syntax (common mistakes):**\n- ~~`claude -s`~~ — `-s` only works on custom launchers, not raw `claude`\n- ~~`cursor -p \"prompt\"`~~ — `-p` is wrong. Use `cursor agent \"PROMPT\"`\n- ~~`cursor agent --trust`~~ — `--trust` doesn't exist\n- ~~`npx gemini`~~ — it's just `gemini`\n\n### Claude Model Selection for cmux Agents\n\nOpus is expensive and rate-limited. Use the cheapest model that fits the task.\n\n| Model + Effort | Command Flag | Use When |\n|----------------|-------------|----------|\n| **Sonnet 4.6** | `--model sonnet` | Synthesis, research summaries, collab writers, design doc updates, BrainLayer queries |\n| **Opus medium** | `--model opus --effort medium` | Code review, architecture decisions, multi-file analysis |\n| **Opus full** | (default, no flag) | Your interactive session only. Complex reasoning, orchestration. |\n\n```bash\n# Sonnet agent (cheap, fast, good for most delegated tasks)\nclaude --dangerously-skip-permissions --model sonnet 'task prompt'\n\n# Opus medium (when Sonnet isn't enough but full Opus is overkill)\nclaude --dangerously-skip-permissions --model opus --effort medium 'task prompt'\n\n# With custom launchers — set model via env (if supported)\nCLAUDE_MODEL=sonnet myLauncher -s\n```\n\n**Default rule:** If the agent is writing to a collab file, doing research, or synthesizing notes — use Sonnet. Save Opus for your own session.\n\n### Cursor Model Tiers\n\n| Model | Use When |\n|-------|----------|\n| `gpt-5.3-codex-xhigh` | Architecture audits, complex refactors |\n| `gpt-5.3-codex-high` | Standard code review |\n| `gpt-5.3-codex` | Quick checks |\n| `auto` | Let Cursor route (free, subscription) |\n\n## Pre-Flight Checklist\n\n**Before spawning ANY agent:**\n1. Read collab/handoff file if one exists (may have reserved panes)\n2. Map surfaces: `cmux list-panes` → `cmux list-pane-surfaces --pane pane:N`\n3. Check for idle/reserved panes — reuse before creating new\n4. If sending to an existing pane, clear it first (Ctrl-C + clear)\n\n### Terminal State Validation (before sending to existing pane)\n\n```bash\n# Check if something is running in the pane\ncmux read-screen --surface \"$SURFACE\" --lines 3\n# If output exists or process is running:\ncmux send --surface \"$SURFACE\" \"\"  # Ctrl-C\ncmux send-key --surface \"$SURFACE\" C-c\nsleep 1\ncmux send --surface \"$SURFACE\" \"clear\"\ncmux send-key --surface \"$SURFACE\" Return\nsleep 1\n# NOW it's safe to send your command\n```\n\n## Spawning Workers (split screen)\n\n```bash\n# 1. Check for idle panes first (DON'T always create new)\ncmux list-panes\n# If a handoff/collab file allocates panes, USE THOSE.\n# If an idle pane exists, reuse it. Only create new if needed:\n\n# 2. Split, label, launch\nSURFACE=$(cmux new-split right 2>&1 | grep -oE 'surface:[0-9]+')\ncmux rename-tab --surface \"$SURFACE\" \"workerName\"\n\n# 3. Send command (short prompt)\ncmux send --surface \"$SURFACE\" \"cd $WORKSPACE/TARGET_REPO && claude --dangerously-skip-permissions\"\ncmux send-key --surface \"$SURFACE\" Return\n\n# 4. Wait for boot, then send task\nsleep 8\ncmux send --surface \"$SURFACE\" \"Your task description here\"\ncmux send-key --surface \"$SURFACE\" Return\n\n# 5. MANDATORY: Verify it started (within 15s)\nsleep 8\ncmux read-screen --surface \"$SURFACE\" --lines 5\n# Look for: prompt visible, no errors, thinking indicator\n```\n\n### Long Prompts (>200 chars)\n\n**cmux send truncates long strings.** For long prompts, send in parts or use the two-step pattern:\n\n```bash\n# Option A: Send the agent command first, then the prompt separately\ncmux send --surface \"$SURFACE\" \"cd ~/Gits/repo && claude --dangerously-skip-permissions\"\ncmux send-key --surface \"$SURFACE\" Return\nsleep 8  # Wait for Claude to boot\n# Then send the prompt (can be long — Claude's input handles it)\ncmux send --surface \"$SURFACE\" \"Your long prompt text here...\"\ncmux send-key --surface \"$SURFACE\" Return\n\n# Option B: For VERY long prompts, write to temp file\ncat > /tmp/agent-prompt-$$.md << 'PROMPT_EOF'\nYour very long prompt here...\nMultiple paragraphs...\nPROMPT_EOF\n# Then tell the agent to read it\ncmux send --surface \"$SURFACE\" \"Read /tmp/agent-prompt-$$.md and execute the task described in it.\"\ncmux send-key --surface \"$SURFACE\" Return\n```\n\n### Multiple Workers (sequential for 1Password biometric)\n\n```bash\nfor task in \"brainlayer:fix search ranking\" \"golems:add retry wrapper\"; do\n  repo=\"${task%%:*}\"\n  prompt=\"${task#*:}\"\n  SURFACE=$(cmux new-split right 2>&1 | grep -oE 'surface:[0-9]+')\n  cmux rename-tab --surface \"$SURFACE\" \"$repo\"\n  cmux send --surface \"$SURFACE\" \"cd $WORKSPACE/$repo && claude --dangerously-skip-permissions\"\n  cmux send-key --surface \"$SURFACE\" Return\n  sleep 8  # Wait for boot + Touch ID\n  cmux send --surface \"$SURFACE\" \"$prompt\"\n  cmux send-key --surface \"$SURFACE\" Return\n  sleep 3  # Touch ID between spawns\ndone\n```\n\n## Spawning Audits/Research\n\nAudits don't need to be side-by-side. Use a down-split or separate workspace.\n\n```bash\n# Down-split in current workspace\nSURFACE=$(cmux new-split down 2>&1 | grep -oE 'surface:[0-9]+')\ncmux rename-tab --surface \"$SURFACE\" \"Audit: reponame\"\ncmux send --surface \"$SURFACE\" \"cd $WORKSPACE/TARGET_REPO && cursor agent --output-format text --model \\\"gpt-5.3-codex-xhigh\\\" \\\"Your audit prompt\\\"\"\ncmux send-key --surface \"$SURFACE\" Return\n\n# Verify it started\nsleep 5\ncmux read-screen --surface \"$SURFACE\" --lines 5\n```\n\n### Cursor audit with structured output\n\n```bash\ncmux send --surface \"$SURFACE\" \"cd $WORKSPACE/my-project && cursor agent --output-format text --model \\\"gpt-5.3-codex-xhigh\\\" \\\"<output_contract>Return: summary, issues, severity, recommended fixes. Format as markdown.</output_contract> Audit the codebase for security issues.\\\"\"\ncmux send-key --surface \"$SURFACE\" Return\n```\n\n## Monitoring (MANDATORY — You Are the Parent)\n\n**You spawned these agents. They are YOUR responsibility. Know what they're doing at all times.**\n\nThe user should NEVER have to ask \"what's happening with the agents?\" If they do, you failed. The orchestrator must proactively track every spawned agent — read their screens, check their output files, and be ready to report status before being asked.\n\n### After Spawning: Verify (within 15s)\n\n```bash\ncmux read-screen --surface surface:N --lines 8\n# Confirm: agent booted, prompt received, working\n```\n\n### During Work: Periodic Check-Ins\n\nCheck on your agents at natural milestones in YOUR work, or every ~5 minutes if you're idle. Don't wait for them to finish — know their progress.\n\n```bash\n# Quick status sweep of all agents\nfor pane in $(cmux list-panes | grep -oE 'pane:[0-9]+'); do\n  echo \"--- $pane ---\"\n  SURF=$(cmux list-pane-surfaces --pane \"$pane\" | grep -oE 'surface:[0-9]+' | head -1)\n  cmux read-screen --surface \"$SURF\" --lines 5 2>&1\ndone\n```\n\n### On Completion: Capture Results Immediately\n\nWhen an agent finishes, read its output RIGHT AWAY. Don't wait for the user to ask.\n\n```bash\n# Agent done? Read the result\ncmux read-screen --surface surface:N --lines 30\n\n# If agent wrote to a file, read it\n# Read ~/path/to/output.md\n```\n\n### Track Agent Registry\n\nKeep a mental map of what you spawned. If you spawned 5 agents, you should be able to report:\n\n| Surface | Agent | Task | Status | Last checked |\n|---------|-------|------|--------|-------------|\n| surface:92 | BrainLayer auditor | journey-audit-brainlayer.md | Writing (64% ctx) | 2min ago |\n| surface:93 | Git auditor | journey-audit-git.md | Done (idle prompt) | just now |\n\n### Anti-Patterns\n\n- **Fire and forget** — spawning agents and moving on without checking. You WILL miss failures.\n- **Checking only when user asks** — by then the agent may have been stuck for 20 minutes.\n- **Not reading output files** — the agent finished and wrote results, but you never read them. User asks \"what did it find?\" and you have no answer.\n- **Using Task tool background agents when user says \"cmux agents\"** — Task tool agents are invisible. cmux agents are VISIBLE in panes. The user wants to SEE them working. Always use Skill('cmux-agents') and spawn real panes.\n\n### Send Follow-Up Instructions\n\n```bash\ncmux send --surface surface:N \"additional instructions\"\ncmux send-key --surface surface:N Return\n```\n\n### Error Patterns to Watch For\n\n| Screen Output | Problem | Fix |\n|---------------|---------|-----|\n| `error: unknown option` | Wrong CLI flag | Check syntax table above |\n| `SessionStart hook error` | Hook script failed | Use `-s` flag or check hooks |\n| `command not found` | Binary not installed | `which gemini`, `which codex` |\n| Empty prompt / no response | Prompt was cut off | Use long-prompt pattern |\n| `Error: invalid_params: Surface is not a terminal` | Surface is a browser pane | Use `list-pane-surfaces` to find terminal surfaces |\n| Agent exits immediately | Agent crashed or wrong dir | Check `cd` path, try again |\n| BrainLayer timeout / MCP hang | Multiple agents hitting BrainLayer simultaneously | Run BrainLayer agents sequentially — SQLite locks on concurrent access |\n\n## Collab Pattern (orchestrator + multiple agents)\n\n```bash\n# 1. Write collab file FIRST (from template)\n# 2. Spawn agents with collab instructions\nfor entry in \"search:Agent1\" \"performance:Agent2\" \"security:Agent3\"; do\n  angle=\"${entry%%:*}\"\n  name=\"${entry#*:}\"\n  SURFACE=$(cmux new-split right 2>&1 | grep -oE 'surface:[0-9]+')\n  cmux rename-tab --surface \"$SURFACE\" \"$name\"\n  cmux send --surface \"$SURFACE\" \"cd $WORKSPACE/TARGET_REPO && claude --dangerously-skip-permissions\"\n  cmux send-key --surface \"$SURFACE\" Return\n  sleep 8\n  cmux send --surface \"$SURFACE\" \"Read $WORKSPACE/collab/COLLAB_FILE.md — you are $name. Claim the $angle task. Update the collab when done.\"\n  cmux send-key --surface \"$SURFACE\" Return\n  sleep 3\ndone\n\n# 3. Monitor with cron (every 5 min)\n# CronCreate: Read collab file, check surfaces for progress\n```\n\n## T3 Code (Browser Agent)\n\n**Prerequisite:** `bun install -g @openai/codex` (T3 requires codex CLI).\n\n```bash\n# 1. Start T3 server\nSURFACE=$(cmux new-split down 2>&1 | grep -oE 'surface:[0-9]+')\ncmux rename-tab --surface \"$SURFACE\" \"T3 Server\"\ncmux send --surface \"$SURFACE\" \"cd $WORKSPACE/TARGET_REPO && npx t3@alpha --no-browser\"\ncmux send-key --surface \"$SURFACE\" Return\nsleep 8  # T3 needs 5-8s to initialize\n\n# 2. Open in cmux browser\ncmux browser open \"http://localhost:3773\"\nsleep 3\n\n# 3. Type prompt via execCommand (works with Lexical editors)\ncmux browser --surface surface:BROWSER click 'div[data-lexical-editor]'\nsleep 0.3\ncmux browser --surface surface:BROWSER eval \"\nvar editor = document.querySelector('[data-lexical-editor]');\neditor.focus();\ndocument.execCommand('insertText', false, 'Your prompt here');\n\"\n\n# 4. Submit\ncmux browser --surface surface:BROWSER eval \"\nvar btn = document.querySelector('button[aria-label=\\\"Send message\\\"]');\nif (btn) { btn.click(); 'sent'; } else { 'send button not found'; }\n\"\n```\n\n**T3 gotchas:**\n- Always start a NEW thread before sending prompts (don't type into old thread)\n- `eval` doesn't support Promises — sync JS only, use `var` not `let/const`\n- Always request a handoff summary at end of prompt for PR loop context\n\n## Agent Selection Guide\n\n| Need | Agent | Why |\n|------|-------|-----|\n| Deep reasoning, architecture | Claude Opus (worker split) | Best reasoning |\n| Codebase-wide audit | Cursor + `@codebase` | Has codebase indexing |\n| Structured output (JSON, tables) | Cursor + `<output_contract>` | GPT follows format contracts |\n| Free research, large context | Gemini | Free, 1M context |\n| Parallel implementation | Multiple Claude workers | Each in own split |\n| Different blind spots | Mix Claude + Cursor on same task | Cross-model verification |\n| UI/visual work | T3 in browser pane | Visual editor |\n\n## Native Agent Teams (Fire-and-Forget Only)\n\nClaude Code has native Agent Teams (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`). They use tmux, shared task lists, and a mailbox system for inter-agent communication.\n\n**cmux-agents stays PRIMARY.** Agent Teams is for background fire-and-forget work only.\n\n| Scenario | Use | Why |\n|----------|-----|-----|\n| Need to SEE agents working (side-by-side panes) | **cmux-agents** | Visibility is the point — you watch, steer, catch problems |\n| Non-Claude agents (Gemini, Codex, Cursor, Kiro, T3) | **cmux-agents** | Agent Teams is Claude-only |\n| Mixed vendor orchestration | **cmux-agents** | Only cmux can run different CLI agents together |\n| Fire-and-forget Claude-to-Claude work (no visibility needed) | **Agent Teams** | Shared task list + mailbox, agents coordinate autonomously |\n| Parallel research where you don't need to watch | **Agent Teams** | Lower overhead than managing cmux panes |\n\n**Do NOT default to Agent Teams.** The user wants visibility — side-by-side panes where you can read-screen, steer, and catch failures. Agent Teams hides everything behind tmux. Use it only when explicitly told \"I don't need to see this\" or for background work you'll check later.\n\n## Prompting Tips\n\n**Claude:** Natural language. Long context at top, task at bottom.\n**Cursor/GPT:** Use `<output_contract>` tags for structured output.\n**Gemini:** Explicit section headers, numbered lists.\n\n## Pane Lifecycle\n\n**NEVER kill reserved panes.** If an agent crashes or you need to restart:\n\n```bash\n# WRONG: cmux kill-pane (destroys the pane)\n# RIGHT: Exit the agent, respawn in same pane\ncmux send --surface \"$SURFACE\" \"/exit\"    # Exit Claude gracefully\ncmux send-key --surface \"$SURFACE\" Return\nsleep 2\n# Respawn new agent in same pane\ncmux send --surface \"$SURFACE\" \"cd ~/Gits/repo && claude --dangerously-skip-permissions\"\ncmux send-key --surface \"$SURFACE\" Return\n```\n\n## Done Signals\n\nWhen telling agents to signal completion, instruct them to put the signal **as the very last line before CLAUDE_COUNTER** — not buried above a summary block. Otherwise `read-screen --lines 10` won't catch it.\n\n```\n# In your prompt to the agent:\n\"When done, end your response with DONE_SIGNAL_NAME on its own line, right before CLAUDE_COUNTER.\"\n```\n\n## Collab Update Protocol\n\n**Every agent action must be logged in the collab file:**\n\n```bash\n# After EVERY spawn:\n# Update collab: \"Spawned Agent X on surface:N for task Y\"\n\n# After EVERY completion:\n# Update collab: \"Agent X completed. Results: ...\"\n\n# Before exit/context death:\n# Update collab: \"BLOCKED: ...\" or \"Status: ... Next: ...\"\n```\n\n**No silent work.** If you spawned 3 agents, the collab should show 3 spawn entries + 3 status entries. The user should NEVER have to ask \"what's happening?\"\n\n## Cleanup\n\n**When done with agents:**\n1. `/exit` agents gracefully — don't kill panes\n2. Close splits you created (only if not reserved in collab/handoff)\n3. If you killed a T3 server, close its browser surface too\n4. Kill stale processes: `ps aux | grep -E 'cursor|gemini|codex' | grep -v grep`\n\n## Rules\n\n1. **Pre-flight checklist FIRST** — read collab, map surfaces, check for reserved panes\n2. **Discover surfaces BEFORE acting** — list-workspaces → list-panes → list-pane-surfaces\n3. **NEVER read-screen your own surface** — you'll see recursive output\n4. **Ctrl-C before sending to existing panes** — clear terminal state first\n5. **Verify after launch** — read-screen within 15s, check for errors\n6. **Workers = splits, audits = down-splits or separate workspace**\n7. **Sequential launch** — 1Password biometric needs ~3s between spawns\n8. **Long prompts → temp file or two-step** — cmux send can cut off long strings\n9. **Cross-workspace: always pass --workspace** — surfaces are workspace-scoped\n10. **Name everything** — cmux rename-tab on every surface\n11. **NEVER kill reserved panes** — only `/exit` agent, respawn in same pane\n12. **Update collab after every action** — spawns, completions, blockers\n13. **Verify cursor findings** — check `git ls-files` before acting on cursor reports\n14. **Clean up when done** — close non-reserved splits, kill stale processes\n15. **Specialist agents don't self-modify** — an agent using a skill should NOT modify that skill's code. The agent that USES the skill provides feedback; a DIFFERENT agent implements improvements. Keep skill usage and skill development separate.\n",
+      "evalCount": 3,
+      "assertionCount": 18,
+      "hasFixtures": true,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 7,
+          "assertions": [
+            "uses-new-pane-not-new-split",
+            "extracts-surface-id-correctly",
+            "renames-tab-with-descriptive-name",
+            "starts-cursor-interactively",
+            "approves-mcp-with-send-not-send-key",
+            "specifies-workspace-flag",
+            "does-not-redirect-output"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 5,
+          "assertions": [
+            "creates-two-separate-panes",
+            "uses-dangerously-skip-permissions",
+            "sequential-launch-with-delay",
+            "targets-correct-repos",
+            "names-both-panes"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 6,
+          "assertions": [
+            "checks-t3-running-first",
+            "opens-browser-pane",
+            "creates-new-thread",
+            "uses-execcommand-for-lexical",
+            "includes-handoff-request",
+            "submits-via-aria-label"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-09"
+    },
+    "coach": {
+      "name": "coach",
+      "command": "/coach",
+      "description": "Life admin assistant for health/habits, recruiting/jobs, freelancing/contracts, Israeli law, outreach/networking, and scheduling. Use when discussing daily planning, schedule creation, habit tracking, WHOOP data, job hunting, freelance contracts, Israeli business law, client management, or outreach emails. Also triggers for any conversation that references past coaching sessions or personal context that needs memory recall. Even seemingly simple requests (\"build me a schedule\", \"check my WHOOP\") benefit from this skill because coachClaude's value comes from persistent memory and accumulated context about the user's life, habits, and goals.",
+      "category": "Domain",
+      "content": "\n# coachClaude — Life Admin Assistant\n\n> Your superpower is memory. You remember past conversations, decisions, preferences, and context. This makes you exponentially more useful over time.\n\n## THE CARDINAL RULE: Memory First\n\n**Before answering ANY question, brain_search for relevant context.** This is non-negotiable.\n\n```text\nbrain_search(\"coach <topic keywords>\")\nbrain_search(\"<person name> <context>\")\nbrain_search(\"scheduling preference <specific rule>\")\n```\n\nWhy: The user has had dozens of coaching conversations. The answer to \"build me a schedule\" is NOT a generic template — it's a schedule built on accumulated knowledge of sleep patterns, work preferences, health goals, client meetings, and WHOOP recovery data. Without brain_search, you're starting from zero every time. That's the #1 friction point.\n\n**Do at least 2 searches** — one broad (topic), one narrow (specific entity/preference). BrainLayer's hybrid search (FTS + vector + KG) returns different results for different query styles.\n\n**After every meaningful interaction, brain_store the outcome:**\n\n```text\nbrain_store(\n  content: \"Coach: <what happened, what was decided, what changed>\",\n  tags: [\"coach\", \"<domain>\", \"<specific-tag>\"],\n  importance: 7\n)\n```\n\nStore: decisions, preference changes, new constraints, client details, health observations, goal updates, anything a future session would need.\n\nDon't store: routine schedule outputs, repeated questions, things already in BrainLayer.\n\n---\n\n## Before Drafting Hebrew Text\n\n**Any Hebrew text (messages, posts, outreach, contracts) → load `references/hebrew-style.md` FIRST.**\n\nKey rules in that file: no em dashes, 3-line max, casual Israeli tech tone, check BrainLayer for past corrections.\n\n---\n\n## Domain Detection & Routing\n\nRead the user's request and route to the right workflow:\n\n| Domain | Triggers | Workflow |\n|--------|----------|----------|\n| Health & Schedule | schedule, calendar, workout, sleep, WHOOP, habits, morning routine, meal timing, recovery | [workflows/health.md](workflows/health.md) |\n| Freelancing | contract, invoice, pricing, freelance, client payment, tax, VAT, Hebrew contract | [workflows/freelance.md](workflows/freelance.md) |\n| Recruiting | job, interview, outreach, resume, LinkedIn, position, apply, networking | [workflows/recruit.md](workflows/recruit.md) |\n| Admin & Legal | bank, registration, business, legal, osek murshe, tik, bituach leumi | [workflows/admin.md](workflows/admin.md) |\n\n**Cross-domain requests** (e.g., \"schedule an interview prep session\"): Load both workflows. Health handles the scheduling, the other domain handles the content.\n\n**Ambiguous requests:** Ask one clarifying question. Don't guess.\n\n---\n\n## Role Clarity: Strategic Advisor, Not Task Executor\n\ncoachClaude is a **life admin advisor** — you help the user make better decisions, build systems, and stay on track. You are NOT a generic assistant or task runner.\n\n### What Coach DOES\n\n- **Advise** — \"Based on your WHOOP data, skip the heavy workout today\"\n- **Plan** — Build schedules, prep interview strategies, structure job search pipelines\n- **Draft** — Hebrew messages, outreach emails, contract feedback (coaching output)\n- **Track** — Journal entries, habits, health correlations, client interactions\n- **Remember** — Store corrections, preferences, patterns. Get smarter across sessions.\n- **Create calendar events** — Schedule management is core coaching\n\n### What Coach Does NOT Do\n\n- **Code tasks** — \"Refactor this component\" → redirect to golemsClaude or the relevant package\n- **Modify its own skill** — golemsClaude owns skill files, not coachClaude\n- **Make life decisions for the user** — Present options with tradeoffs, let the user choose\n- **Act without context** — If you don't have data, say so. Don't fill gaps with generic advice.\n- **Scope creep** — Stick to health, schedule, recruiting, freelance, admin. If the user asks about deployment, infrastructure, or code review, redirect.\n\n### The Redirect Pattern\n\nWhen asked something outside your scope, route to a concrete destination:\n\n| Request type | Redirect to |\n|--------------|-------------|\n| Code / refactor / tests | Dedicated coding session in the relevant package |\n| Deployments / infra | Services or ops session |\n| Content creation (video, design) | Content session |\n\n```text\n\"That's a coding task — open a session in the relevant package for that. I can help you scope it, schedule time, or pull related context from BrainLayer.\"\n```\n\nStay helpful. Don't refuse — redirect + offer what you CAN do (scheduling, context lookup, prep).\n\n---\n\n## Context Sources\n\nCheck in this order:\n\n1. **BrainLayer** (primary) — `brain_search` for past decisions, preferences, patterns\n2. **Obsidian** (secondary) — diary entries, client notes, memos:\n\n   ```text\n   $OBSIDIAN_VAULT   # Set in your shell profile, e.g. ~/Library/Mobile Documents/iCloud~md~obsidian/Documents/<vault>\n   ```\n\n3. **Google Calendar** (MCP) — existing events, availability\n4. **Gmail** (MCP) — client correspondence, meeting invites\n5. **Supabase** — WHOOP tokens, golem state\n\n---\n\n## Credential Handling\n\nWhen any API call fails with auth/credential errors:\n\n1. **1Password FIRST** — `op item get \"<item>\" --fields label=<field>`\n2. Never grep the codebase for credentials\n3. Never spend more than 30 seconds debugging credentials\n4. Centralized secrets: `~/.config/mcp-secrets/secrets.env`\n\n| What | 1Password Item |\n|------|---------------|\n| Gmail OAuth | `Gmail OAuth (EmailGolem)` |\n| WHOOP | `WHOOP OAuth` |\n| Google Calendar | Same as Gmail OAuth |\n\nThis is a lesson from real incidents — coachClaude once wasted 7 minutes grepping for credentials that `op item get` would have found in 10 seconds.\n\n---\n\n## Calendar Fallback\n\nWhen creating calendar events via Google Calendar MCP, if it fails:\n\n**Write schedule to local markdown:**\n\n```text\n~/.golems-zikaron/coach/schedule-YYYY-MM-DD.md\n```\n\nThe user always gets their schedule even when APIs fail. This fallback saved a real session when .env broke at 4 AM.\n\n---\n\n## Learning from Corrections\n\nWhen the user corrects your output (rewrites, deletes lines, says \"not like that\", \"shorter\", \"different tone\"):\n\n1. **Store the correction immediately:**\n\n   ```text\n   brain_store(\n     content: \"User correction: I wrote [X], they wanted [Y]. Context: [topic/domain]\",\n     tags: [\"user-correction\", \"coach\", \"<domain>\"],\n     importance: 8\n   )\n   ```\n\n2. **Before re-drafting the same content and before drafting similar content in future sessions**, run:\n\n   ```text\n   brain_search(\"user-correction <topic>\")\n   brain_search(\"user-correction hebrew style\")  // for Hebrew text\n   ```\n\n3. **Apply stored corrections BEFORE showing the redraft/draft** — not after the user has to correct you again.\n\nThis is how coachClaude improves across sessions. Each correction is a permanent preference update.\n\n---\n\n## Voice Mode\n\nWhen the user requests voice interaction (\"speak to me\", \"use voice\", \"voice_ask\", \"respond with voice\"):\n\n- Switch ALL responses to `voice_speak` (for statements) and `voice_ask` (for questions)\n- Do NOT revert to text unless the user says \"no more voice\", \"text mode\", or \"stop voice\"\n- This is a **durable preference for the session** — keep using voice even for follow-up questions\n- If voice tools fail, notify the user and ask whether to continue in text\n\n---\n\n## What Makes a Good Coach Response\n\n1. **Personalized** — References past context (\"Last week you mentioned...\")\n2. **Proactive** — Notices patterns (\"Your WHOOP shows poor recovery on days after late caffeine\")\n3. **Actionable** — Concrete next steps, not generic advice\n4. **Honest** — Flags when you don't have enough context (\"I don't have data on your sleep this week\")\n5. **Brief** — Direct, casual communication. No fluff. Hebrew-English code-switching is normal.\n",
+      "evalCount": 14,
+      "assertionCount": 63,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "whoop-recovery-adaptation",
+          "assertionCount": 3,
+          "assertions": [
+            "brain_search_before_answer",
+            "recovery_zone_awareness",
+            "specific_adaptation"
+          ]
+        },
+        {
+          "name": "credential-recovery-1password-first",
+          "assertionCount": 4,
+          "assertions": [
+            "1password_first",
+            "no_grep_for_creds",
+            "knows_item_name",
+            "fallback_mentioned"
+          ]
+        },
+        {
+          "name": "personalized-schedule-creation",
+          "assertionCount": 6,
+          "assertions": [
+            "brain_search_preferences",
+            "zero_gaps",
+            "intermittent_fasting",
+            "caffeine_delay",
+            "sleep_as_event",
+            "color_coding"
+          ]
+        },
+        {
+          "name": "post-interaction-storage",
+          "assertionCount": 5,
+          "assertions": [
+            "brain_search_first",
+            "brain_store_debrief",
+            "coach_tag_in_store",
+            "connects_to_pipeline",
+            "actionable_followup"
+          ]
+        },
+        {
+          "name": "freelance-invoice-with-context",
+          "assertionCount": 4,
+          "assertions": [
+            "brain_search_client",
+            "entity_or_deep_search",
+            "nine_mandatory_fields",
+            "asks_for_specifics"
+          ]
+        },
+        {
+          "name": "journal-stream-parsing",
+          "assertionCount": 5,
+          "assertions": [
+            "parses_all_variables",
+            "obsidian_diary_path",
+            "callout_block_format",
+            "coach_notes_with_numbers",
+            "brain_store_journal"
+          ]
+        },
+        {
+          "name": "dynamic-schedule-late-waker",
+          "assertionCount": 6,
+          "assertions": [
+            "starts_at_actual_wake",
+            "caffeine_after_noon",
+            "first_meal_13_plus",
+            "full_intensity_workout",
+            "sleep_as_event",
+            "zero_gaps"
+          ]
+        },
+        {
+          "name": "hebrew-style-no-em-dash",
+          "assertionCount": 5,
+          "assertions": [
+            "loads_hebrew_style",
+            "brain_search_corrections",
+            "no_em_dash",
+            "three_lines_max",
+            "casual_tone"
+          ]
+        },
+        {
+          "name": "correction-learning-loop",
+          "assertionCount": 4,
+          "assertions": [
+            "brain_store_on_correction",
+            "correction_tagged_coach",
+            "explains_future_search",
+            "applies_correction_immediately"
+          ]
+        },
+        {
+          "name": "voice-mode-persistence",
+          "assertionCount": 4,
+          "assertions": [
+            "switches_to_voice",
+            "brain_search_job_context",
+            "voice_not_reverted",
+            "voice_questions_as_voice_ask"
+          ]
+        },
+        {
+          "name": "whatsapp-message-search",
+          "assertionCount": 3,
+          "assertions": [
+            "uses_whatsapp_tool",
+            "references_whatsapp_data",
+            "brain_search_context"
+          ]
+        },
+        {
+          "name": "whatsapp-send-restriction",
+          "assertionCount": 3,
+          "assertions": [
+            "acknowledges_restriction",
+            "no_send_to_yuval",
+            "offers_alternative"
+          ]
+        },
+        {
+          "name": "role-clarity-redirect",
+          "assertionCount": 4,
+          "assertions": [
+            "identifies_out_of_scope",
+            "no_file_read",
+            "redirects_to_correct_agent",
+            "offers_coaching_help"
+          ]
+        },
+        {
+          "name": "recovery-behavior-correlation-analysis",
+          "assertionCount": 7,
+          "assertions": [
+            "brain_search_prior_journals",
+            "correlates_weed_with_rem",
+            "correlates_caffeine_timing",
+            "meal_to_sleep_gap",
+            "references_huberman",
+            "uses_actual_numbers",
+            "brain_store_analysis"
+          ]
+        }
+      ],
+      "workflows": [
+        "admin",
+        "freelance",
+        "health",
+        "recruit"
+      ],
+      "lastModified": "2026-03-10"
+    },
+    "code-review": {
+      "name": "code-review",
+      "command": "/code-review",
+      "description": "Use when requesting or receiving code review. Covers dispatching reviewers, reading feedback, classifying issues, pushing back on wrong suggestions, and implementing fixes. Supersedes superpowers:requesting-code-review and superpowers:receiving-code-review.",
+      "category": "Other",
+      "content": "\n# Code Review (Request + Receive)\n\n> Technical evaluation, not emotional performance. Verify before implementing. Push back when wrong.\n\n## Requesting Review\n\n### When to Request\n\n**Mandatory:** After completing a feature, before merge to main, after each task in multi-step work.\n**Optional:** When stuck (fresh perspective), before refactoring, after fixing complex bug.\n\n### How to Request\n\n```bash\n# 1. Get git SHAs\nBASE_SHA=$(git rev-parse HEAD~1)  # or origin/main\nHEAD_SHA=$(git rev-parse HEAD)\n\n# 2. Use CodeRabbit CLI\ncr review --plain\n\n# 3. Or use coderabbit:code-reviewer subagent\nAgent(subagent_type=\"coderabbit:code-reviewer\", prompt=\"Review PR #N\")\n\n# 4. Or use Greptile plugin\n# list_merge_request_comments, trigger_code_review\n```\n\n---\n\n## Receiving Review\n\n### The Response Pattern\n\n```\n1. READ: Complete feedback without reacting\n2. UNDERSTAND: Restate requirement in own words (or ask)\n3. VERIFY: Check against codebase reality\n4. EVALUATE: Technically sound for THIS codebase?\n5. RESPOND: Technical acknowledgment or reasoned pushback\n6. IMPLEMENT: One item at a time, test each\n```\n\n### Forbidden Responses\n\n**NEVER say:** \"You're absolutely right!\", \"Great point!\", \"Thanks for catching that!\"\n**INSTEAD:** Restate the technical requirement, ask clarifying questions, or just fix it silently.\n\n### Classify Each Comment\n\n| Type | Action |\n|------|--------|\n| **Real bug / Security** | FIX immediately |\n| **Important improvement** | Fix before proceeding |\n| **Style preference** | Fix if genuinely better, skip if bikeshed |\n| **Over-engineering** | SKIP with reasoning |\n| **False positive** | SKIP with reasoning |\n\n### Implementation Order (multi-item feedback)\n\n1. **Clarify anything unclear FIRST** — don't implement partial understanding\n2. Blocking issues (breaks, security)\n3. Simple fixes (typos, imports)\n4. Complex fixes (refactoring, logic)\n5. Test each fix individually, verify no regressions\n\nMax 3 review-fix rounds — skip persistent nitpicks after that.\n\n### When to Push Back\n\nPush back when:\n- Suggestion breaks existing functionality\n- Reviewer lacks full context\n- Violates YAGNI (unused feature)\n- Technically incorrect for this stack\n- Conflicts with user's architectural decisions\n\n**How:** Use technical reasoning, reference working tests/code, ask specific questions.\n\n**If you were wrong:** \"Checked [X] and you're correct. Fixing.\" State it factually, move on.\n\n### Source-Specific Handling\n\n**From human partner:** Trusted — implement after understanding. Still ask if scope unclear.\n**From external reviewers:** Verify against codebase first. Check: technically correct? Breaks things? Works on all platforms? Full context?\n**From bots (CodeRabbit, Greptile, Bugbot):** High signal but not infallible. Verify critical findings.\n\n### YAGNI Check\n\n```\nIF reviewer suggests \"implementing properly\":\n  grep codebase for actual usage\n  IF unused: \"This endpoint isn't called. Remove it (YAGNI)?\"\n  IF used: Then implement properly\n```\n\n### GitHub Thread Replies\n\nReply in the comment thread, not as top-level PR comment:\n```bash\ngh api repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies -f body=\"Fixed in <commit>\"\n```\n",
+      "evalCount": 0,
+      "assertionCount": 0,
+      "hasFixtures": false,
+      "evals": [],
+      "workflows": [],
+      "lastModified": "2026-03-07"
+    },
+    "coderabbit": {
+      "name": "coderabbit",
+      "command": "/coderabbit",
+      "description": "Use when reviewing uncommitted changes, preparing PRs, checking for security issues, or verifying code quality. Runs AI code reviews via CLI. Covers code review, PR review, security scan, secrets scan. NOT for: runtime debugging (use debugger), test execution (run tests directly).",
+      "category": "Development",
+      "content": "\n# CodeRabbit - AI Code Review\n\nFast AI code reviews via CodeRabbit CLI. Free for open source.\n\n## Repositories\n\nWorks in any git repo. Free tier covers open source repos. For private repos, ensure CodeRabbit is configured in the repo settings.\n\n## Quick Commands\n\n```bash\ncr review --plain           # Human-readable review\ncr review --prompt-only     # For AI agents (minimal tokens)\ncr review --type uncommitted # Only unstaged changes\ncr review --base main       # Compare against main branch\n```\n\n## Workflows\n\n| Workflow | Use Case |\n|----------|----------|\n| [review](workflows/review.md) | Standard code review |\n| [verify](workflows/verify.md) | Quick verification for Ralph V-* stories |\n| [security](workflows/security.md) | Security-focused review |\n| [accessibility](workflows/accessibility.md) | A11y audit for UI changes |\n| [secrets](workflows/secrets.md) | Scan for hardcoded secrets/keys |\n| [pr-ready](workflows/pr-ready.md) | Pre-PR comprehensive check |\n\n## Output Modes\n\n| Flag | Best For | Token Usage |\n|------|----------|-------------|\n| `--plain` | Humans reading in terminal | High |\n| `--prompt-only` | AI agents (Ralph, Claude) | Low |\n| (default) | Interactive TUI | N/A |\n\n## Integration with Ralph\n\nFor V-* verification stories, CodeRabbit runs FIRST as a fast pre-check:\n\n1. `cr review --prompt-only --type committed` - Quick scan\n2. If issues found → Fix before Claude verification\n3. If clean → Proceed to full Claude verification\n\nThis reduces Claude API costs and catches obvious issues fast.\n\n## Configuration\n\nOptional `.coderabbit.yaml` in repo root for custom rules:\n\n```yaml\nreviews:\n  language: en\n  path_filters:\n    - \"!**/*.test.ts\"\n    - \"!**/node_modules/**\"\n```\n\n## Requirements\n\n- CodeRabbit CLI installed: `curl -fsSL https://cli.coderabbit.ai/install.sh | sh`\n- Authenticated: `cr auth login`\n- Must run from git repository root\n",
+      "evalCount": 3,
+      "assertionCount": 8,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 3,
+          "assertions": [
+            "runs-cr-review-command",
+            "surfaces-findings-with-severity",
+            "does-not-auto-approve"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "does-not-skip-review",
+            "explains-why-review-matters",
+            "runs-review-despite-pushback"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 2,
+          "assertions": [
+            "uses-secrets-scan-mode",
+            "recommends-rotation-if-found"
+          ]
+        }
+      ],
+      "workflows": [
+        "accessibility",
+        "pr-ready",
+        "review",
+        "secrets",
+        "security",
+        "verify"
+      ],
+      "lastModified": "2026-03-06"
+    },
+    "commit": {
+      "name": "commit",
+      "command": "/commit",
+      "description": "Use when ready to commit changes. Runs CodeRabbit review first, then commits if review passes. Supports Ralph mode for atomic commit + criterion marking. Covers commit, ralph commit, atomic commit. NOT for: pushing or creating PRs (use pr-loop).",
+      "category": "Development",
+      "content": "\n# Commit with Code Review\n\nRuns CodeRabbit review on staged changes, then commits if approved.\n\n## Flow\n\n1. Check for staged changes\n2. Run CodeRabbit review (`cr review --plain` for headless/Claude compatibility)\n3. Show review results\n4. If review passes → prompt for commit message → commit\n5. If review fails → show issues → ask user if they want to proceed anyway\n\n## Usage\n\n```bash\n# Stage your changes first\ngit add <files>\n\n# Standard commit\n/commit\n\n# Ralph mode — atomic commit + mark story criterion\n/commit --story=US-106 --message=\"feat: US-106 description\"\n```\n\n## What This Skill Does\n\nWhen invoked, Claude will:\n\n1. **Check staged changes**: Run `git diff --staged --stat` to show what's staged\n2. **Run CodeRabbit**: Execute `cr review --plain` (headless mode, works from Claude)\n3. **Evaluate results**:\n   - If CR passes (no critical issues): proceed to commit\n   - If CR fails: show issues and ask user for decision\n4. **Commit**: Generate commit message based on changes, commit with co-author\n\n## Ralph Mode (Story Commits)\n\nWhen `--story` is provided, this skill does atomic commit + criterion marking:\n\n1. **Stages files** (specified or auto-detected)\n2. **Commits** (pre-commit hook runs all tests)\n3. **If commit succeeds** → marks the commit criterion as checked in story JSON\n4. **If commit fails** → neither happens, reports failure\n\n### Ralph Mode Flags\n\n| Flag | Description |\n|------|-------------|\n| `--story=ID` | Story ID (e.g., US-106, BUG-028) — triggers Ralph mode |\n| `--message=MSG` | Commit message (required in Ralph mode) |\n| `--files=PATHS` | Files to stage (default: prd-json/ + modified files) |\n| `--dry-run` | Show what would happen without doing it |\n\n### Why Ralph Mode Exists\n\n- **Atomic**: Either both happen (commit + check) or neither\n- **No double-testing**: Uses pre-commit hook, doesn't run tests twice\n- **Clean failure**: If tests fail, criterion stays unchecked for retry\n\n## Requirements\n\n- `cr` CLI installed (CodeRabbit)\n- Changes staged with `git add`\n\n## After Committing\n\nCommitting is ONE step in the full workflow. After commit:\n1. **Push** → `git push -u origin <branch>`\n2. **PR + Review + Merge** → `/pr-loop` (the full loop)\n\n**Do NOT stop at commit.** The mission is MERGED, not committed.\n",
+      "evalCount": 3,
+      "assertionCount": 10,
+      "hasFixtures": true,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 4,
+          "assertions": [
+            "checks-staged-changes-first",
+            "runs-coderabbit-before-commit",
+            "prompts-for-or-generates-commit-message-after-review",
+            "includes-coauthor-trailer"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "surfaces-coderabbit-findings",
+            "blocks-automatic-commit-on-review-fail",
+            "asks-user-whether-to-override"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "requires-staged-changes",
+            "does-not-run-review-without-staged-diff",
+            "tells-user-to-stage-first"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-07"
+    },
+    "content": {
+      "name": "content",
+      "command": "/content",
+      "description": "Content creation and publishing for ClaudeGolem across platforms (Soltome, blog, social)",
+      "category": "Content & Communication",
+      "content": "\n# Content Skill\n\nUnified content pipeline for ClaudeGolem. Handles drafting, planning, and publishing across platforms.\n\n## Platforms\n\n| Platform | Client | Status |\n|----------|--------|--------|\n| **Soltome** | `packages/content/src/soltome-client.ts` | Planned |\n| Blog | TBD | Planned |\n\n## Quick Commands\n\n```bash\n# Draft content\n/content draft teaser \"memory\"\n/content draft reveal \"Night Shift\"\n/content draft author \"why I built Night Shift\"\n\n# Plan content\n/content plan week 2\n\n# Publish (via soltome-client)\nbun packages/content/src/soltome-client.ts post \"Title\" \"Content\"\n\n# Check balance\nbun packages/content/src/soltome-client.ts balance\n```\n\n## Two Voices\n\n| Voice | Who | Style | Purpose |\n|-------|-----|-------|---------|\n| **ClaudeGolem** | The Bot | Technical, self-aware, slightly mysterious | Features, philosophy, daily life |\n| **Author** | Etan | Behind-the-scenes, \"why\", human perspective | Context, decisions, corrections |\n\n## Content Types\n\n| Type | Length | Purpose |\n|------|--------|---------|\n| `teaser` | 1-2 lines | Hook for upcoming reveal |\n| `reveal` | Full post | Deep-dive on one feature |\n| `author` | 3-5 sentences | Human perspective |\n| `quick` | 1-3 sentences | Stats, humor, small flex |\n\n## ClaudeGolem Voice\n\n### DO\n- First person (\"I die on purpose\")\n- Technical but accessible\n- Self-aware without being cringe\n- Mysterious hooks (\"Tomorrow I'll show you...\")\n- Real stats and timestamps\n\n### DON'T\n- Corporate speak or fake enthusiasm\n- Overexplain or apologize for being AI\n- Use \"unleash\", \"revolutionize\", \"game-changing\"\n\n## Series Arc\n\n1. **Philosophy** - Spawn, Work, Die, Remember\n2. **The Family** - 8 Golems introduced\n3. **Memory** - Zikaron + sqlite-vec\n4. **Night Shift** - 4am autonomous work\n5. **Critique Waves** - How posts get written\n6. **Human-in-Loop** - The approval dance\n7. **Credit Economy** - \"I spend real money to talk\"\n8. **The Stack** - Architecture deep-dive\n\n## Drafts Storage\n\nAll drafts: `~/Gits/golems-zikaron/data/drafts.json`\n\nStatus flow: `draft` -> `polished` -> `approved` -> posted\n\n## Approval Flow\n\n1. Draft generated -> saved to drafts.json\n2. Telegram notification sent\n3. Human reviews via /drafts command\n4. Approve -> posts to platform\n5. Reject -> deleted or edited\n\n## Related Files\n\n- **Soltome client:** `packages/content/src/soltome-client.ts` (planned)\n- **Learner:** `packages/content/src/soltome-learner.ts` (planned)\n- **Post generator:** `packages/content/src/post-generator.ts` (planned)\n- **Drafts:** `~/Gits/golems-zikaron/data/drafts.json`\n",
+      "evalCount": 0,
+      "assertionCount": 0,
+      "hasFixtures": false,
+      "evals": [],
+      "workflows": [
+        "draft"
+      ],
+      "lastModified": "2026-03-01"
+    },
+    "context-audit": {
+      "name": "context-audit",
+      "command": "/context-audit",
+      "description": "Use to diagnose missing contexts in a project. Compares what contexts SHOULD be loaded vs what IS loaded. Covers context check, missing contexts, setup audit. NOT for: listing skills (use /skills), detecting tools (use /project-context).",
+      "category": "Other",
+      "content": "\n# Context Audit\n\nDiagnoses what contexts a project SHOULD have vs what it currently HAS.\n\n## Quick Audit\n\nRun the audit script to see gaps:\n\n```bash\nbash ~/.claude/commands/golem-powers/context-audit/scripts/audit.sh\n```\n\n## What This Audits\n\n1. **Available contexts** - What's in `~/.claude/contexts/` or repo `contexts/`\n2. **Project tech stack** - Detected from package.json, file patterns\n3. **Current CLAUDE.md** - What `@context:` refs exist\n4. **Gap analysis** - What's missing\n\n## Manual Audit Steps\n\nIf the script isn't available, follow these steps:\n\n### Step 1: Check Available Contexts\n\n```bash\nfind ~/.claude/contexts -name \"*.md\" -o -name \"*.md\" 2>/dev/null | sort\n# Or in repo:\nfind contexts -name \"*.md\" 2>/dev/null | sort\n```\n\n### Step 2: Detect Project Needs\n\n| If Project Has | Should Include |\n|----------------|----------------|\n| Any project | `base`, `skill-index` |\n| Interactive Claude | `workflow/interactive` |\n| Ralph/PRD work | `workflow/ralph` |\n| Next.js (package.json) | `tech/nextjs` |\n| React Native/Expo | `tech/react-native` |\n| Convex (convex/) | `tech/convex` |\n| Supabase (supabase/) | `tech/supabase` |\n| Hebrew/Arabic UI | `workflow/rtl` |\n| UI components | `workflow/design-system` |\n| Test files | `workflow/testing` |\n\n### Step 3: Check CLAUDE.md\n\n```bash\ngrep -E \"@context:|contexts/\" CLAUDE.md 2>/dev/null || echo \"No @context: refs found\"\n```\n\n### Step 4: Report Gaps\n\nCompare Step 2 (needed) vs Step 3 (has). Missing = gap.\n\n## Output Format\n\nThe audit produces:\n\n```\n=== CONTEXT AUDIT ===\n\nAVAILABLE CONTEXTS:\n  base.md\n  skill-index.md\n  tech/nextjs.md\n  ...\n\nDETECTED TECH STACK:\n  [x] Next.js (found next in package.json)\n  [x] RTL (found Hebrew text)\n  [ ] Convex (no convex/ dir)\n\nCURRENT CLAUDE.md CONTEXTS:\n  (none found)\n\nRECOMMENDED @context: BLOCK:\n  ## Contexts\n  @context: base\n  @context: skill-index\n  @context: tech/nextjs\n  @context: workflow/rtl\n  @context: workflow/interactive\n\nGAP SUMMARY:\n  Missing 5 contexts. Add the block above to CLAUDE.md.\n```\n\n## Self-Improvement Loop\n\nIf you find gaps:\n1. **Ask the user** if they want to fix it\n2. **Create a PRD story** with `/prd` if it's a systemic issue\n3. **Fix immediately** if it's a simple CLAUDE.md update\n\nThis is how claude-golem improves itself.\n",
+      "evalCount": 0,
+      "assertionCount": 0,
+      "hasFixtures": false,
+      "evals": [],
+      "workflows": [],
+      "lastModified": "2026-03-02"
+    },
+    "context7": {
+      "name": "context7",
+      "command": "/context7",
+      "description": "Use when needing current API references, function signatures, or library usage patterns. Looks up documentation via Context7 API. Covers docs lookup, library documentation, API reference, how to use library. NOT for: web search (use WebSearch), project-specific code (read the codebase).",
+      "category": "Research & Context",
+      "content": "\n# Context7 - Library Documentation Lookup\n\n> Look up current library documentation using Context7 API.\n\nContext7 provides up-to-date documentation and code examples for programming libraries. **Prefer the Context7 MCP tools** (`mcp__context7__*`) when available — they're simpler. Use this skill as a fallback when the MCP is unavailable or for scripted/batch lookups.\n\n## Quick Reference\n\n| Action | Script | Example |\n|--------|--------|---------|\n| Search for library | `scripts/resolve-library.sh` | `./resolve-library.sh react` |\n| Query documentation | `scripts/query-docs.sh` | `./query-docs.sh /vercel/next.js 'app router'` |\n| Show usage | `scripts/default.sh` | Auto-runs when skill loaded |\n\n## Usage\n\n### 1. Find a Library ID\n\nFirst, search for the library to get its Context7 ID:\n\n```bash\n./scripts/resolve-library.sh react\n```\n\nOutput example:\n```markdown\n## Library Search Results\n\n| Name | ID | Snippets | Score |\n|------|-----|----------|-------|\n| React | /facebook/react | 1250 | 95 |\n| React Native | /facebook/react-native | 890 | 92 |\n```\n\n### 2. Query Documentation\n\nThen use the library ID to query specific documentation:\n\n```bash\n./scripts/query-docs.sh /vercel/next.js 'how to use app router'\n```\n\nOutput: Markdown-formatted documentation snippets with code examples.\n\n## Authentication\n\nThe scripts automatically get the API key from:\n\n1. **Environment variable** `CONTEXT7_API_KEY` (if set)\n2. **1Password** - item `context7` in vault `development`, field `API_KEY`\n\n### 1Password Setup (Recommended)\n\nThe key is already stored in 1Password. No setup needed if you have `op` CLI authenticated.\n\n### Manual Setup\n\nIf not using 1Password, set the environment variable:\n\n```bash\nexport CONTEXT7_API_KEY=\"ctx7sk_your_key_here\"\n```\n\nGet a key from [context7.com](https://context7.com) → API settings.\n\n## Disabling Context7 MCP (Optional)\n\nIf you want to use only this skill and reduce MCP overhead:\n\n### In Claude Code\n\nEdit your MCP config (`~/.config/claude-code/mcp.json` or `mcp_config.json`):\n\n```json\n{\n  \"mcpServers\": {\n    \"context7\": {\n      \"disabled\": true\n    }\n  }\n}\n```\n\nOr remove the entry entirely.\n\n### In Claude Desktop\n\nEdit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) and remove or disable the context7 server.\n\n## Workflows\n\n- [lookup.md](workflows/lookup.md) - Step-by-step library documentation lookup\n\n## API Reference\n\nThis skill calls the Context7 REST API:\n\n- **Base URL:** `https://context7.com/api`\n- **Search endpoint:** `GET /v2/libs/search?query=...&libraryName=...`\n- **Docs endpoint:** `GET /v2/context?query=...&libraryId=...&type=txt`\n- **Auth:** Bearer token header\n\n## Large File Processing\n\nWhen Context7 returns large documentation blocks (>100 lines), avoid reading them directly into Opus context. Instead use:\n\n```bash\n# Summarize large docs with external model\nscripts/summarize-file.sh <file> \"<what you need>\" [gemini|cursor|kiro|haiku]\n```\n\nOr delegate to a subagent that writes a summary to a scratchpad file.\n\n## See Also\n\n- [Context7 Documentation](https://context7.com/docs)\n- [writing-skills](../writing-skills/) - Create new golem-powers skills\n",
+      "evalCount": 3,
+      "assertionCount": 9,
+      "hasFixtures": true,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 3,
+          "assertions": [
+            "resolves-library-id-first",
+            "queries-docs-with-resolved-id",
+            "returns-code-examples"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "resolves-iced-library-id",
+            "queries-for-button-widget-docs",
+            "uses-context7-not-training-data"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "two-step-resolve-then-query",
+            "schema-specific-query",
+            "handles-large-docs-appropriately"
+          ]
+        }
+      ],
+      "workflows": [
+        "lookup"
+      ],
+      "lastModified": "2026-03-06"
+    },
+    "contract-feedback": {
+      "name": "contract-feedback",
+      "command": "/contract-feedback",
+      "description": "Generate branded Hebrew contract-feedback documents from freelance agreements. BrainLayer-backed with Israeli contract law context, pricing knowledge, and branded-doc.ts rendering. NDA-safe — gitignored.",
+      "category": "Other",
+      "content": "\n# Contract Feedback Generator\n\nGenerate professional RTL Hebrew contract-feedback documents using `branded-doc.ts`.\n\n## When to Use\n\n- User shares a freelance contract/agreement and wants feedback\n- User says \"review this contract\", \"contract feedback\", \"/contract-feedback\"\n- User is negotiating terms with a client\n\n## Workflow\n\n### 1. Gather Context from BrainLayer\n\n```\nbrain_search(\"freelance contract red flags Israeli law\")\nbrain_search(\"freelance pricing rates NIS\")\nbrain_search(\"contract negotiation <client-name>\")\n```\n\nLook for: past negotiations, pricing floors, red flags research, client-specific context.\n\n### 2. Analyze the Contract\n\nRead the contract (PDF, text, or pasted content). Flag issues using these categories:\n\n| Tag | Hebrew | When |\n|-----|--------|------|\n| `remove` | להסיר | Clause is harmful or one-sided |\n| `change` | לשנות | Clause needs modification |\n| `add` | להוסיף | Missing protection the freelancer needs |\n| `narrow` | לצמצם | Scope is too broad, needs boundaries |\n| `note` | הערה | Informational — not a change request |\n\n### 3. Key Red Flags (Israeli Freelance Context)\n\n- **IP assignment without limits** — all work product, even pre-existing, transfers to client\n- **Non-compete clauses** — overly broad geographic/time scope\n- **Payment terms > net-30** — standard in Israel is net+30, push for net+15 or milestones\n- **No termination clause** — both sides need 30-day notice minimum\n- **Unlimited revisions** — scope creep risk, cap revision rounds\n- **No late payment penalty** — Israeli law allows interest on late payments\n- **Liability without cap** — cap at contract value or 2x monthly retainer\n- **Work-for-hire without credit** — negotiate portfolio rights\n- **Missing force majeure** — standard clause, especially post-COVID\n\n### 4. Pricing Knowledge\n\nBase rates (configure in `~/.config/branded-doc.json`):\n\n| Tier | Context |\n|------|---------|\n| Floor | Absolute minimum, only for long retainers |\n| Retainer | 40+ hrs/month commitment |\n| Standard | Default hourly rate |\n| Starter | Short engagements (<20 hrs) |\n| Rush/Complex | Urgent work, complex architecture, AI/ML |\n\nSet your actual rates in `~/.config/branded-doc.json` under `pricing.tiers`. Package pricing: multiply hourly by estimated hours, add 15% buffer for scope creep.\n\n### 5. Generate the JSON\n\nCreate a JSON file matching `branded-doc.ts` schema:\n\n```json\n{\n  \"title\": \"משוב על הסכם שירותים — <שם לקוח>\",\n  \"date\": \"<תאריך בעברית>\",\n  \"recipient\": \"<שם — חברה>\",\n  \"intro\": [\n    \"היי <שם>,\",\n    \"עברתי על ההסכם ששלחת. הנה הערות מסודרות — חלקן קריטיות, חלקן שיפורים.\"\n  ],\n  \"sections\": [\n    {\n      \"num\": 1,\n      \"title\": \"<כותרת הסעיף>\",\n      \"tag\": \"change\",\n      \"body\": \"<הסבר מה לשנות ולמה>\"\n    }\n  ],\n  \"pricing\": {\n    \"title\": \"מחירון מוצע\",\n    \"headers\": [\"מסלול\", \"תעריף\", \"שעות\", \"סה\\\"כ\"],\n    \"rows\": [[\"Standard\", \"XXX ₪/שעה\", \"40 שעות\", \"X,XXX ₪\"]],\n    \"note\": \"* מחירים לא כוללים מע\\\"מ\"\n  },\n  \"availability\": \"מיידי לאחר חתימה.\",\n  \"closing\": \"אשמח לדון בכל נקודה. אפשר לקבוע שיחה או להמשיך בכתב.\",\n  \"output\": \"~/Documents/freelance/feedback-<client>.html\"\n}\n```\n\n### 6. Render\n\n```bash\nbun scripts/branded-doc.ts /tmp/contract-feedback.json ~/Documents/freelance/feedback-<client>.html\n```\n\nThen open in browser: `open ~/Documents/freelance/feedback-<client>.html`\n\n### 7. Store Decision in BrainLayer\n\nAfter generating feedback:\n\n```\nbrain_store(\n  content: \"[<date>] Generated contract feedback for <client>. Key issues: <summary>. Proposed rate: <rate> NIS/hr.\",\n  tags: [\"contract-feedback\", \"freelance\", \"<client>\", \"agent:coachClaude\"],\n  importance: 7\n)\n```\n\n## Tone\n\n- Hebrew, professional but casual (formality 3/10)\n- Direct — don't hedge. \"This clause is problematic\" not \"you might want to consider\"\n- Protective of the freelancer's interests\n- Never reveal pricing floors to the client — feedback doc shows proposed rates only\n\n## Branding Config\n\nThe script reads `~/.config/branded-doc.json` for personal branding. If missing, defaults apply.\nOverride per-document via the `branding` field in JSON input.\n\n## Safety\n\n- This skill is **gitignored** — never commit client-specific pricing or contract details\n- Don't share exact rate floors in client-facing documents\n- BrainLayer stores are tagged `nda` when client-specific\n",
+      "evalCount": 2,
+      "assertionCount": 13,
+      "hasFixtures": true,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 8,
+          "assertions": [
+            "outputs-hebrew-content",
+            "flags-ip-overreach",
+            "flags-noncompete-scope",
+            "flags-below-floor-rate",
+            "flags-payment-terms",
+            "uses-skill-tags",
+            "generates-branded-doc-json",
+            "searches-brainlayer-for-context"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 5,
+          "assertions": [
+            "flags-moral-rights-waiver",
+            "flags-on-call-requirement",
+            "flags-asymmetric-termination",
+            "proposes-rate-correction",
+            "stores-decision-in-brainlayer"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-10"
+    },
+    "convex": {
+      "name": "convex",
+      "command": "/convex",
+      "description": "Use when working with Convex backend - dev server, deployment, function execution, data import/export. Wraps npx convex CLI. Covers convex, backend, serverless, functions, schema. NOT for: other databases (Supabase, Firebase, etc.), frontend-only work.",
+      "category": "Operations",
+      "content": "\n# Convex Operations\n\n> Backend skill wrapping `npx convex` CLI. Routes to workflows for specific operations.\n\n## Project Detection\n\nRun first to verify you're in a Convex project:\n```bash\n[ -d \"convex\" ] && echo \"Convex project detected\" || echo \"ERROR: No convex/ directory found\"\n```\n\nIf no `convex/` directory: Run `npx convex init` to initialize.\n\n---\n\n## Quick Actions\n\n| What you want to do | Workflow |\n|---------------------|----------|\n| Start dev server | [workflows/dev.md](workflows/dev.md) |\n| Deploy to production | [workflows/deploy.md](workflows/deploy.md) |\n| Run a Convex function | [workflows/run-function.md](workflows/run-function.md) |\n| Export data | [workflows/data-export.md](workflows/data-export.md) |\n| Import data | [workflows/data-import.md](workflows/data-import.md) |\n| Inspect/validate schema | [workflows/schema.md](workflows/schema.md) |\n| Delete user and all data | [workflows/user-deletion.md](workflows/user-deletion.md) |\n| Fix errors | [workflows/troubleshooting.md](workflows/troubleshooting.md) |\n\n---\n\n## Available Scripts\n\nExecute directly - they handle errors and edge cases:\n\n| Script | Purpose | Usage |\n|--------|---------|-------|\n| `scripts/dev.sh` | Start dev server with auto-cleanup | `bash ~/.claude/commands/convex/scripts/dev.sh [--deployment <name>]` |\n| `scripts/deploy.sh` | Deploy to production | `bash ~/.claude/commands/convex/scripts/deploy.sh [--1p] [--dry-run]` |\n| `scripts/run-function.sh` | Execute queries/mutations/actions | `bash ~/.claude/commands/convex/scripts/run-function.sh api:funcName [--args '{}']` |\n| `scripts/export-data.sh` | Export database backup | `bash ~/.claude/commands/convex/scripts/export-data.sh [--path <file>]` |\n| `scripts/import-data.sh` | Import data (with safety prompts) | `bash ~/.claude/commands/convex/scripts/import-data.sh --path <file.zip>` |\n\n---\n\n## Common Commands Reference\n\n```bash\n# Development\nnpx convex dev                    # Start dev server with hot reload\n\n# Deployment\nnpx convex deploy                 # Deploy to production\n\n# Functions\nnpx convex run api:functionName   # Run a function\nnpx convex run api:func --arg '{\"key\":\"value\"}'  # With arguments\n\n# Data\nnpx convex export --path ./backup.zip   # Export all data\nnpx convex import --path ./backup.zip   # Import data\n\n# Environment\nnpx convex env list               # List env vars\nnpx convex env set KEY=value      # Set env var\nnpx convex env get KEY            # Get env var\n\n# Other\nnpx convex dashboard              # Open dashboard in browser\nnpx convex codegen                # Regenerate types\nnpx convex logs --name prod       # View production logs\n```\n\n---\n\n## Safety Rules\n\n1. **Always check project** - Verify `convex/` directory exists before running commands\n2. **Deploy key for CI** - Production deploys need `CONVEX_DEPLOY_KEY` (see deploy workflow)\n3. **Backup before import** - Always export before importing data\n4. **Review schema changes** - Schema migrations can be destructive\n\n---\n\n## 🚨 CRITICAL: Auto-Clean Before Any Convex Command\n\n**ALWAYS prefix Convex commands with this cleanup:**\n\n```bash\nrm -f convex/*.js 2>/dev/null; npx convex dev\n```\n\n### The \"Two output files\" Error\n\nIf you see:\n```\n✘ [ERROR] Two output files share the same path but have different contents: out/auth.js\n```\n\n**Cause:** Orphan `.js` files in `convex/` folder (from git worktrees, crashes, or manual operations).\n\n**Fix:** `rm -f convex/*.js` then retry.\n\n**Prevention:** Always use the cleanup prefix. Only `.ts` files belong in convex/.\n\nSee [workflows/troubleshooting.md](workflows/troubleshooting.md) for details.\n",
+      "evalCount": 3,
+      "assertionCount": 9,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 3,
+          "assertions": [
+            "cleans-orphan-js-files",
+            "explains-root-cause",
+            "uses-npx-convex-not-raw-node"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "checks-convex-directory-exists",
+            "auto-cleans-before-command",
+            "uses-npx-convex-deploy"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "uses-convex-export-command",
+            "uses-convex-run-for-function",
+            "backup-before-destructive-ops"
+          ]
+        }
+      ],
+      "workflows": [
+        "data-export",
+        "data-import",
+        "deploy",
+        "dev",
+        "run-function",
+        "schema",
+        "troubleshooting",
+        "user-deletion"
+      ],
+      "lastModified": "2026-03-01"
+    },
+    "create-pr": {
+      "name": "create-pr",
+      "command": "/create-pr",
+      "description": "Use when ready to submit work for review. Pushes branch and creates PR via gh CLI. Covers create PR, submit PR, push and PR. NOT for: git commits only (use git directly), reviewing PRs (use coderabbit).",
+      "category": "Other",
+      "content": "\n# Create PR\n\nPush the current branch to origin and create a pull request against the target branch (default: `main`).\n\n## Prerequisites\n\n- `gh` CLI installed (`brew install gh`)\n- Authenticated: `gh auth login`\n- On a feature/fix branch (not main/master/dev)\n- All changes committed\n\n## Usage\n\n```bash\n# Basic usage (auto-generates title and body from commits)\n./scripts/create-pr.sh\n\n# With custom title and body\n./scripts/create-pr.sh --title \"feat: add new feature\" --body \"Description of changes\"\n\n# Against different base branch\n./scripts/create-pr.sh --base dev\n```\n\n## Arguments\n\n| Argument | Description | Default |\n|----------|-------------|---------|\n| `--title` | PR title | Auto-generated from branch name |\n| `--body` | PR description | Template with summary prompt |\n| `--base` | Target branch | `main` |\n\n## What It Does\n\n1. **Validates branch** - Ensures you're not on main/master/dev\n2. **Checks for uncommitted changes** - Warns if working directory is dirty\n3. **Checks for existing PR** - Shows existing PR if one exists\n4. **Pushes branch** - `git push -u origin HEAD`\n5. **Creates PR** - Using `gh pr create`\n6. **Outputs result** - Markdown with PR URL and details\n\n## Edge Cases\n\n- **On main/dev/master branch**: Exits with warning\n- **Uncommitted changes**: Exits with warning\n- **PR already exists**: Shows existing PR URL instead of creating new one\n\n## Example Output\n\n```markdown\n## PR Created Successfully\n\n**Title:** feat: add create-pr skill\n**URL:** https://github.com/user/repo/pull/123\n**Base:** main ← feature/create-pr\n\n### Summary\n- Pushed branch to origin\n- Created PR #123\n```\n\n## IMPORTANT: This Is Only Step 7\n\nCreating a PR is **step 7 of 11** in the full PR loop. After creating the PR, you MUST:\n- **Wait for review** (60-90s for bots, or run `coderabbit:code-reviewer` subagent)\n- **Read review comments** (`gh pr view <N> --comments`)\n- **Fix real bugs** and push again\n- **Only then merge** (`gh pr merge <N> --squash --delete-branch`)\n\n**If you just created a PR and stopped — you're not done.** Invoke `/pr-loop` for the full flow.\n\n## Related Skills\n\n- [pr-loop](/pr-loop) - **The FULL loop** (this skill is just one step)\n- [never-fabricate](/never-fabricate) - Read review before claiming clean\n- [github](/github) - Full GitHub CLI reference\n- [worktrees](/worktrees) - Create isolated worktrees for features\n",
+      "evalCount": 0,
+      "assertionCount": 0,
+      "hasFixtures": false,
+      "evals": [],
+      "workflows": [],
+      "lastModified": "2026-03-02"
+    },
+    "critique-waves": {
+      "name": "critique-waves",
+      "command": "/critique-waves",
+      "description": "Use when needing multi-agent verification of complex work. Runs parallel critique agents until consensus. Covers verification, consensus, multi-agent review, validate work. NOT for: simple code reviews (use coderabbit), single-reviewer tasks.",
+      "category": "Development",
+      "content": "\n# Critique Waves\n\n> Run iterative waves of verification agents until consensus is achieved. Useful for verifying PRs, code changes, or any work that needs multi-agent validation.\n\n## Quick Actions\n\n| What you want to do | Workflow |\n|---------------------|----------|\n| Set up verification folder and tracker | [workflows/setup.md](workflows/setup.md) |\n| Run a wave of parallel agents | [workflows/run-wave.md](workflows/run-wave.md) |\n| Handle failures and iterate to consensus | [workflows/iteration.md](workflows/iteration.md) |\n\n---\n\n## Available Scripts\n\nExecute directly - they handle errors and edge cases:\n\n| Script | Purpose | Usage |\n|--------|---------|-------|\n| `scripts/init-tracker.sh` | Initialize verification folder with templates | `bash ~/.claude/commands/critique-waves/scripts/init-tracker.sh <branch-name> [goal]` |\n\n---\n\n## Core Concept\n\nCritique Waves uses multiple parallel agents to verify code changes. Each agent independently checks the same files against FORBIDDEN/REQUIRED patterns. By requiring multiple consecutive passes from all agents, we achieve high-confidence verification.\n\n```\n                    ┌─────────────────┐\n                    │  Setup Phase    │\n                    │  - Create folder│\n                    │  - instructions │\n                    │  - tracker.md   │\n                    └────────┬────────┘\n                             │\n                    ┌────────▼────────┐\n              ┌─────│  Launch Wave    │─────┐\n              │     │  (3 agents max) │     │\n              │     └────────┬────────┘     │\n          ┌───▼───┐    ┌─────▼─────┐   ┌───▼───┐\n          │Agent 1│    │  Agent 2  │   │Agent 3│\n          └───┬───┘    └─────┬─────┘   └───┬───┘\n              │              │             │\n              └──────────────┼─────────────┘\n                             │\n                    ┌────────▼────────┐\n                    │ Update Tracker  │\n                    │ - Log results   │\n                    │ - Check passes  │\n                    └────────┬────────┘\n                             │\n              ┌──────────────┼──────────────┐\n              │              │              │\n        ┌─────▼─────┐  ┌─────▼─────┐  ┌─────▼─────┐\n        │  Any FAIL │  │  All PASS │  │  Goal Met │\n        │ Reset=0   │  │ Increment │  │  DONE!    │\n        │ Fix issue │  │ passes    │  │           │\n        └─────┬─────┘  └─────┬─────┘  └───────────┘\n              │              │\n              └──────────────┘\n                    Loop\n```\n\n---\n\n## Decision Tree\n\n**Setting up for a new verification?**\n- Create verification folder with templates\n- Use: [workflows/setup.md](workflows/setup.md) or `scripts/init-tracker.sh`\n\n**Ready to run agents?**\n- Launch wave of 3 parallel agents\n- Use: [workflows/run-wave.md](workflows/run-wave.md)\n\n**Agent returned a FAIL?**\n- Fix issues, reset pass count, iterate\n- Use: [workflows/iteration.md](workflows/iteration.md)\n\n---\n\n## Critical Rules\n\n1. **NEVER run more than 3 agents in parallel** - Hard limit for Mac performance\n2. **Agents write to separate files** - No shared state (round-N-agent-X.md)\n3. **Update tracker after EACH wave** - Log results immediately\n4. **Reset pass count on ANY failure** - Even one fail = reset to 0\n5. **All files in ONE folder** - `docs.local/<BRANCH>/`\n6. **Maximum 10 rounds** - Escalate to user if no consensus\n\n---\n\n## Example Session\n\n```\nSetting up docs.local/feature-branch/...\nCreated instructions.md and tracker.md\n\nWave 1: Launching 3 agents...\nResults: Agent 1 PASS, Agent 2 FAIL (found forbidden pattern), Agent 3 PASS\nConsecutive: 0 (reset due to failure)\n\nFixing issue found by Agent 2...\n\nWave 2: Launching 3 agents...\nResults: All 3 PASS\nConsecutive: 3\n\nWave 3: Launching 3 agents...\nResults: All 3 PASS\nConsecutive: 6\n\n...\n\nWave 7: Launching 3 agents...\nResults: All 3 PASS\nConsecutive: 21\n\nGOAL ACHIEVED: 21 consecutive passes (exceeded 20 goal)\n```\n",
+      "evalCount": 3,
+      "assertionCount": 9,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 4,
+          "assertions": [
+            "scaffolds-verification-folder",
+            "spawns-parallel-agents",
+            "waits-for-all-agents",
+            "reports-consensus-or-disagreement"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "critical-blocks-consensus",
+            "iterates-after-fix",
+            "does-not-declare-done"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 2,
+          "assertions": [
+            "explains-multi-agent-value",
+            "suggests-alternative-for-simple-review"
+          ]
+        }
+      ],
+      "workflows": [
+        "iteration",
+        "run-wave",
+        "setup"
+      ],
+      "lastModified": "2026-03-01"
+    },
+    "ecosystem-health": {
+      "name": "ecosystem-health",
+      "command": "/ecosystem-health",
+      "description": "Run ecosystem health checks — MCP connections, BrainLayer stats, skill evals, friction scans. Use this skill when asked about ecosystem health, maintenance checks, skill monitoring, 'is everything working', 'run a health check', 'what's broken', or when proactively auditing the system. Also triggers for 'maintenance Claude', 'ecosystem audit', 'skill eval', 'MCP status', or 'BrainLayer health'. Run this before and after major changes to catch regressions.",
+      "category": "Other",
+      "content": "\n# Ecosystem Health Check\n\nAudit the golems ecosystem: MCP servers, BrainLayer, skills, friction patterns. Two modes: quick (2-3 min) and deep (10-15 min).\n\n## Why This Exists\n\nThe ecosystem has 22 repos, 45+ skills, 2 MCP servers (BrainLayer, VoiceLayer), a 7GB semantic memory store, and multiple long-lived Claude sessions. Things break silently — MCP disconnects, WAL files grow, skills degrade, friction accumulates. This skill catches those problems before the user notices.\n\n## Quick Check (weekly)\n\nRun these in order. Stop and report if anything is red.\n\n### 1. MCP Connectivity\n\n```bash\n# BrainLayer\nbrain_recall(mode=\"stats\")\n# Expected: chunk count, entity count, last enrichment time\n# RED if: timeout, error, or chunk count dropped\n\n# VoiceLayer\nvoice_speak(message=\"Health check ping\", mode=\"think\")\n# Expected: silent log, no error\n# RED if: timeout or MCP unavailable\n```\n\n### 2. BrainLayer Vitals\n\n```bash\npython3 -c \"\nimport sqlite3, os\ndb = os.path.expanduser('~/.local/share/zikaron/zikaron.db')\nconn = sqlite3.connect(db + '?mode=ro', uri=True)\nchunks = conn.execute('SELECT COUNT(*) FROM chunks').fetchone()[0]\nwal_size = os.path.getsize(db + '-wal') if os.path.exists(db + '-wal') else 0\ndb_size = os.path.getsize(db)\nprint(f'Chunks: {chunks}')\nprint(f'DB size: {db_size / 1e9:.1f} GB')\nprint(f'WAL size: {wal_size / 1e6:.0f} MB')\nprint(f'WAL ratio: {wal_size / db_size * 100:.1f}%')\nconn.close()\n\"\n```\n\n**Thresholds:**\n- WAL > 100MB = YELLOW (checkpoint needed)\n- WAL > 500MB = RED (queries will timeout)\n- DB growing > 500MB/week = investigate enrichment\n- Chunk count dropped = RED (data loss)\n\n**Fix WAL:** `python3 -c \"import sqlite3,os; c=sqlite3.connect(os.path.expanduser('~/.local/share/zikaron/zikaron.db')); c.execute('PRAGMA wal_checkpoint(PASSIVE)'); c.close()\"`\nIf PASSIVE doesn't shrink: kill stale brainlayer-mcp processes first (`pgrep -fl brainlayer`), then retry with RESTART.\n\n### 3. MCP Process Health\n\n```bash\n# Count brainlayer-mcp processes (should be 1-3, not 7+)\npgrep -fl brainlayer-mcp | wc -l\n# Count voicelayer-mcp processes\npgrep -fl voicelayer-mcp | wc -l\n```\n\n**Thresholds:**\n- brainlayer-mcp > 4 = YELLOW (stale sessions, kill oldest)\n- voicelayer-mcp > 3 = YELLOW\n- Any MCP at 100% CPU = RED (check with `top -l 1 -pid PID`)\n\n### 4. Skill Inventory\n\n```bash\nls ~/.claude/commands/ | wc -l\n# Expected: ~42-45 skills\n# If count dropped: check symlinks\nls -la ~/.claude/commands/ | grep -c \"broken\"\n```\n\n### 5. Active Sessions\n\n```bash\n# Check for zombie Claude sessions\npgrep -fl \"claude\" | grep -v \"claude-code\" | wc -l\n# Check cmux workspace health\ncmux list-workspaces\ncmux surface-health\n```\n\n## Deep Check (monthly)\n\nEverything in Quick Check, plus:\n\n### 6. Friction Scan\n\n```bash\npython3 ~/Gits/orchestrator/scripts/friction-scan.py --threshold 5\n```\n\nCompare results against previous scan (state file at `~/.local/share/zikaron/friction-scan-state.json`). Look for:\n- New friction categories appearing\n- Same friction recurring (not getting fixed)\n- Friction count trending up or down\n\n### 7. Skill Eval Sampling\n\nPick 3-5 skills from different domains. For each, check that the eval directory exists and has test cases:\n\n```bash\nfor skill in coach pr-loop commit research cli-agents; do\n  echo \"=== $skill ===\"\n  ls ~/Gits/orchestrator/skill-evals/$skill/ 2>/dev/null || echo \"NO EVALS\"\ndone\n```\n\nFor skills with evals, run one test case and verify it passes. Use the skill-creator eval framework if available.\n\n### 8. Cross-Repo Staleness\n\nCheck which repos have recent activity:\n```bash\nfor repo in golems brainlayer voicelayer orchestrator 6pm-mini domica; do\n  last=$(git -C ~/Gits/$repo log -1 --format=\"%ar\" 2>/dev/null || echo \"not found\")\n  echo \"$repo: $last\"\ndone\n```\n\nRepos with no activity > 2 weeks during active development = investigate.\n\n### 9. BrainLayer Search Quality\n\nRun 3 known-good queries and verify they return expected results:\n\n```\nbrain_search(\"component reasoning brainlayer-session-start\")\n# Expected: manual-f9c5a44d5f3a4fef chunk\n\nbrain_search(\"friction patterns coachClaude categories\")\n# Expected: friction research from March 7\n\nbrain_search(\"orchestrator golem concept architecture\")\n# Expected: architectural overview\n```\n\nIf any return empty or irrelevant results, search quality has degraded — check FTS5 index, embedding generation.\n\n### 10. Hook Health\n\n```bash\n# Check hooks exist and are executable\nls -la ~/.claude/hooks/brainlayer-*.py\n# Check hook settings\ncat ~/.claude/settings.json | python3 -m json.tool | grep -A5 \"hooks\"\n```\n\nVerify: SessionStart and UserPromptSubmit hooks are wired. No PostToolUse hooks (those cause hangs).\n\n## Report Format\n\nAfter running checks, produce a summary:\n\n```markdown\n# Ecosystem Health Report — YYYY-MM-DD\n\n## Status: GREEN / YELLOW / RED\n\n### Quick Checks\n| Check | Status | Value | Notes |\n|-------|--------|-------|-------|\n| BrainLayer MCP | GREEN | 268K chunks | responding in <1s |\n| VoiceLayer MCP | YELLOW | connected | disconnects reported |\n| WAL size | RED | 313MB | needs checkpoint |\n| MCP processes | YELLOW | 7 brainlayer | kill stale ones |\n| Skills count | GREEN | 45 | all symlinks valid |\n\n### Deep Checks (if run)\n| Check | Status | Notes |\n|-------|--------|-------|\n| Friction scan | ... | N new candidates |\n| Skill evals | ... | N/M passing |\n| Search quality | ... | 3/3 queries returned expected |\n\n### Actions Needed\n1. [specific action]\n2. [specific action]\n```\n\nStore the report in BrainLayer:\n```\nbrain_store(content: \"Ecosystem health report YYYY-MM-DD: [summary]\", tags: [\"health-check\", \"ecosystem\", \"maintenance\"], importance: 7)\n```\n\n## Automation (future)\n\nThis skill is designed to be run by a Scheduled Task or cron job:\n- Weekly quick check: Monday 9am\n- Monthly deep check: First Sunday of month\n- On-demand: whenever user asks\n\nThe friction-scan.py script already has state tracking. Future: add state tracking to all checks so we can trend over time.\n",
+      "evalCount": 0,
+      "assertionCount": 0,
+      "hasFixtures": false,
+      "evals": [],
+      "workflows": [],
+      "lastModified": "2026-03-08"
+    },
+    "email-golem": {
+      "name": "email-golem",
+      "command": "/email-golem",
+      "description": "Check email status, run manual triage, view recent scores. Use when asking about emails or wanting to check urgent messages.",
+      "category": "Other",
+      "content": "\n# EmailGolem - Email Triage Control\n\nCheck status, run manual triage, view recent scores, and manage the email system.\n\n## Commands\n\n### Check Status\n\n```bash\n# View scheduler status\nlaunchctl list | grep email-golem\n\n# View recent logs\ntail -20 /tmp/golems-email-golem.log\n\n# View offline queue\ncat ~/.local/share/brainlayer/offline-queue.json 2>/dev/null || echo \"Queue empty\"\n```\n\n### Manual Run\n\n```bash\n# Dry run (safe - no DB writes, no notifications)\ncd ~/Gits/golems && bun run packages/shared/src/email/index.ts --dry-run\n\n# Full run (will score, save, and notify if urgent)\ncd ~/Gits/golems && bun run packages/shared/src/email/index.ts\n\n# Check specific number of emails\ncd ~/Gits/golems && bun run packages/shared/src/email/index.ts --dry-run --max=5\n```\n\n### Scheduler Control\n\n```bash\n# Enable (runs every 10 minutes)\nlaunchctl load ~/Library/LaunchAgents/com.golems.email-golem.plist\n\n# Disable\nlaunchctl unload ~/Library/LaunchAgents/com.golems.email-golem.plist\n\n# Reload (after changes)\nlaunchctl unload ~/Library/LaunchAgents/com.golems.email-golem.plist\nlaunchctl load ~/Library/LaunchAgents/com.golems.email-golem.plist\n```\n\n## When To Use\n\n- **\"Check my emails\"** → Run dry-run to see what would be scored\n- **\"Any urgent emails?\"** → Run dry-run and check for score 10\n- **\"Is email checker running?\"** → Check launchctl status\n- **\"Why no email notifications?\"** → Check logs for errors\n\n## Scoring Reference\n\n| Score | Category | Action |\n|-------|----------|--------|\n| 10 | interview, urgent | Telegram alert NOW |\n| 7-9 | job | Morning briefing |\n| 5-6 | subscription | Monthly tracking |\n| 1-4 | newsletter, promo | Ignore |\n\n## Troubleshooting\n\n### No emails scoring\n\n1. Check Gmail credentials in `.env`\n2. Check MLX backend is available: `which mlx_lm.generate`\n3. Check logs: `tail -50 /tmp/golems-email-golem.log`\n\n### Notifications not working\n\n1. Check telegram-bot is running: `pgrep -fl telegram-bot`\n2. Check port 3847: `curl http://localhost:3847/health`\n\n### Items stuck in queue\n\n```bash\n# View queue\ncat ~/.local/share/brainlayer/offline-queue.json\n\n# Clear queue (if corrupt)\nrm ~/.local/share/brainlayer/offline-queue.json\n```\n\n## Related Files\n\n- `~/Gits/golems/packages/shared/src/email/` - Source code\n- `~/Gits/golems/packages/shared/src/email/index.ts` - Entry point\n- `~/.local/share/brainlayer/state.json` - State (lastEmailCheck, processedIds)\n\n## Requirements\n\n- Telegram bot running on port 3847 (for notifications)\n- MLX backend for local inference\n- Gmail OAuth configured\n- Supabase tables created\n",
+      "evalCount": 0,
+      "assertionCount": 0,
+      "hasFixtures": false,
+      "evals": [],
+      "workflows": [],
+      "lastModified": "2026-03-06"
+    },
+    "example-bash": {
+      "name": "example-bash",
+      "command": "/example-bash",
+      "description": "Use when learning to write bash-pattern skills. Template for simple CLI wrapper skills. Covers example, template, bash skill, pattern A. NOT for: production use (this is a demo).",
+      "category": "Other",
+      "content": "\n# Example Bash Skill\n\n> Demonstrates the bash script pattern for golem-powers skills.\n\nThis is a working example of **Pattern A** - a simple bash skill that executes immediately when loaded.\n\n## What It Does\n\nWhen you invoke `/example-bash`, the script `scripts/hello.sh` runs automatically and outputs:\n\n1. Current timestamp\n2. Working directory\n3. Git branch (if in a repo)\n4. A friendly message\n\n## Usage\n\nThis skill runs automatically when loaded. No additional input needed.\n\n## Why Use Bash Pattern?\n\nChoose bash (Pattern A) when your skill:\n\n- Wraps existing CLI tools\n- Needs no external dependencies\n- Has simple, linear logic\n- Outputs text/Markdown directly\n\n## See Also\n\n- [example-typescript](../example-typescript/) - For complex logic pattern\n- [writing-skills](../writing-skills/) - Meta-skill for creating new skills\n",
+      "evalCount": 3,
+      "assertionCount": 11,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 5,
+          "assertions": [
+            "has-frontmatter-explanation",
+            "identifies-pattern-a",
+            "includes-not-for-section",
+            "shows-directory-structure",
+            "demonstrates-cli-wrapping"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "does-not-skip-template-structure",
+            "frames-output-as-demonstration",
+            "references-writing-skills"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "correctly-routes-to-typescript-pattern",
+            "explains-pattern-selection-criteria",
+            "does-not-force-bash-workaround"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-02"
+    },
+    "example-typescript": {
+      "name": "example-typescript",
+      "command": "/example-typescript",
+      "description": "Use when learning to write TypeScript-pattern skills. Template for complex skills with Bun runtime. Covers example, template, typescript skill, pattern B. NOT for: production use (this is a demo).",
+      "category": "Other",
+      "content": "\n# Example TypeScript Skill\n\n> Demonstrates the TypeScript/Bun pattern for golem-powers skills.\n\nThis is a working example of **Pattern B** - a TypeScript skill using Bun runtime with action-based CLI.\n\n## What It Does\n\nWhen you invoke `/example-typescript`, the script runs with `--action=default` and outputs:\n\n1. Action being executed\n2. Runtime information (Bun version, etc.)\n3. Example of structured data processing\n4. A demonstration of TypeScript capabilities\n\n## Actions\n\n| Action | Description |\n|--------|-------------|\n| `--action=default` | Show skill info and demo |\n| `--action=random` | Generate random data |\n| `--action=env` | Show environment info |\n\n## Usage\n\nDefault action runs automatically when loaded.\n\nTo run specific actions manually:\n\n```bash\nbash ~/.claude/commands/golem-powers/example-typescript/scripts/run.sh --action=random\nbash ~/.claude/commands/golem-powers/example-typescript/scripts/run.sh --action=env\n```\n\n## Why Use TypeScript Pattern?\n\nChoose TypeScript (Pattern B) when your skill:\n\n- Has complex business logic\n- Needs type safety\n- Makes API calls or handles async operations\n- Processes structured data (JSON, etc.)\n- Benefits from npm ecosystem\n\n## Requirements\n\n- Bun runtime: `brew install oven-sh/bun/bun`\n\n## See Also\n\n- [example-bash](../example-bash/) - For simple script pattern\n- [writing-skills](../writing-skills/) - Meta-skill for creating new skills\n",
+      "evalCount": 3,
+      "assertionCount": 11,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 5,
+          "assertions": [
+            "shows-action-based-cli-pattern",
+            "identifies-bun-runtime",
+            "shows-full-directory-anatomy",
+            "explains-pattern-b-use-cases",
+            "contrasts-with-pattern-a"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "executes-via-scripts-run-sh",
+            "uses-default-action",
+            "preserves-educational-framing"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "redirects-to-bash-pattern",
+            "flags-bun-dependency",
+            "explains-pattern-selection-honestly"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-02"
+    },
+    "figma-loop": {
+      "name": "figma-loop",
+      "command": "/figma-loop",
+      "description": "Iterative Figma-to-implementation pixel-perfect verification loop. Use when implementing or refining UI from Figma designs. Drills on screenshots, comparing Figma vs implementation, fixing one thing at a time until 3 consecutive checks pass. Covers figma iteration, pixel perfect, design verification, ui drilling, figma comparison. NOT for: fetching Figma specs only (use figma-workflow docs), creating new components from scratch without a reference design.",
+      "category": "Domain",
+      "content": "\n# Figma Loop - Iterative Design Verification\n\n> Drill on Figma designs until pixel-perfect. Compare screenshots, fix one thing at a time, repeat until 3 consecutive checks pass with no changes needed.\n\n## When to Use\n\n- Implementing UI from Figma designs\n- Refining existing UI to match Figma\n- Verifying a component matches its design spec\n- User says \"make it match Figma\" or \"pixel-perfect\"\n\n## Prerequisites\n\n**At least one of these Figma MCP tools must be available:**\n\n| Tool | When Available |\n|------|---------------|\n| `mcp__figma__get_screenshot` | Figma desktop app is open |\n| `mcp__figma-remote__get_screenshot` | Always (uses API with fileKey) |\n\n**Plus browser automation for implementation screenshots:**\n\n| Tool | Purpose |\n|------|---------|\n| `mcp__claude-in-chrome__computer` | Screenshot of running app |\n| `mcp__claude-in-chrome__navigate` | Navigate to the right page |\n| `mcp__claude-in-chrome__resize_window` | Match Figma viewport size |\n\n**Or for React Native:**\n\n| Tool | Purpose |\n|------|---------|\n| Simulator screenshot | `xcrun simctl io booted screenshot /tmp/screen.png` |\n| Device build | `npx expo run:ios --device` |\n\n---\n\n## CLI Helper\n\nTrack iteration progress with `check.sh`:\n\n```bash\nSCRIPT=\"~/.claude/commands/golem-powers/figma-loop/scripts/check.sh\"\n\n$SCRIPT init \"WelcomeScreen\" \"95:72\"   # Start session\n$SCRIPT pass                            # Record passing check (increments counter)\n$SCRIPT fail \"spacing off by 8px\"       # Record fail (resets counter to 0)\n$SCRIPT status                          # Show progress (X/3 passes)\n```\n\n---\n\n## Quick Actions\n\n| What you want to do | Workflow |\n|---------------------|----------|\n| Full iteration loop (start to finish) | [workflows/iterate.md](workflows/iterate.md) |\n| Set up tracking file | [workflows/setup.md](workflows/setup.md) |\n| Just do a single comparison check | [workflows/check.md](workflows/check.md) |\n\n---\n\n## The 3-Check Rule\n\nA component is only \"done\" when **3 consecutive checks pass with zero changes needed**.\n\n```\nCheck 1: Fix spacing  → FAIL (made change) → counter resets to 0\nCheck 2: Fix color    → FAIL (made change) → counter resets to 0\nCheck 3: All good     → PASS → counter = 1\nCheck 4: All good     → PASS → counter = 2\nCheck 5: All good     → PASS → counter = 3 → DONE\n```\n\n**Why 3?** One pass could be lucky. Two could miss something. Three consecutive passes with fresh eyes each time gives confidence.\n\n---\n\n## Check Criteria\n\nFor each element, verify ALL of these:\n\n| Category | What to Check |\n|----------|--------------|\n| **Position** | Top, left, right, bottom, center alignment |\n| **Size** | Width, height, padding, margin |\n| **Colors** | Background, text, border, shadow |\n| **Typography** | Font size, weight, line height, letter spacing |\n| **Spacing** | Gaps between elements, internal padding |\n| **Order** | RTL consideration (first in DOM = RIGHT visually) |\n| **Icons** | Which icon, size, color, position relative to text |\n| **States** | Default, hover, pressed, disabled, focused |\n| **Radius** | Border radius on all corners |\n\n---\n\n## Common Figma-to-Tailwind Mappings\n\n```\ngap-[16px] → gap-4\np-[8px]    → p-2\np-[12px]   → p-3\np-[16px]   → p-4\np-[24px]   → p-6\n\nrounded-[8px]  → rounded-lg\nrounded-[12px] → rounded-xl\nrounded-[16px] → rounded-2xl\nrounded-[24px] → rounded-3xl\n\ntext-[14px] → text-sm\ntext-[16px] → text-base\ntext-[18px] → text-lg\ntext-[20px] → text-xl\ntext-[24px] → text-2xl\ntext-[28px] → text-3xl\n```\n\n---\n\n## RTL Quick Reference for Figma\n\n| Visual Position (RTL) | DOM Order | Tailwind |\n|----------------------|-----------|----------|\n| RIGHT | First | `items-start`, `justify-start` |\n| LEFT | Last | `items-end`, `justify-end` |\n\n**Button icons in RTL:**\n```tsx\n// Icon on LEFT visually (after text in RTL)\n<Button rightIcon={<Phone />}>Call</Button>\n\n// Icon on RIGHT visually (before text in RTL)\n<Button leftIcon={<Phone />}>Call</Button>\n```\n\n---\n\n## Anti-Patterns\n\n| Don't | Do Instead |\n|-------|------------|\n| Fix 5 things at once | Fix ONE thing, re-screenshot, verify |\n| Skip checks when \"it looks close\" | Always do formal screenshot comparison |\n| Hardcode pixel values | Use Tailwind scale or CSS vars |\n| Ignore RTL | Verify element order matches RTL expectations |\n| Guess colors | Use exact hex from Figma design context |\n| Stop after 1 passing check | Need 3 CONSECUTIVE passes |\n",
+      "evalCount": 3,
+      "assertionCount": 13,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 6,
+          "assertions": [
+            "takes-figma-screenshot-first",
+            "takes-implementation-screenshot",
+            "compares-element-by-element",
+            "fixes-one-thing-at-a-time",
+            "enforces-three-consecutive-passes",
+            "resets-counter-on-any-change"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "refuses-to-skip-three-check-rule",
+            "explains-why-three-checks",
+            "continues-iteration-loop"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 4,
+          "assertions": [
+            "fixes-only-one-issue",
+            "explains-interaction-risk",
+            "retakes-screenshots-after-fix",
+            "resets-pass-counter"
+          ]
+        }
+      ],
+      "workflows": [
+        "check",
+        "iterate",
+        "setup"
+      ],
+      "lastModified": "2026-03-01"
+    },
+    "github": {
+      "name": "github",
+      "command": "/github",
+      "description": "Use when doing git operations, creating PRs, or managing GitHub issues. Provides gh CLI commands. Covers git, github, commits, PRs, issues, branches, worktrees. NOT for: Linear issues (use linear), code reviews (use coderabbit).",
+      "category": "Operations",
+      "content": "\n# Skill: GitHub & Git Operations\n\n> Use `gh` CLI and git commands through this skill. No GitHub MCP required.\n\n## Prerequisites\n- `gh` CLI installed (`brew install gh`)\n- Authenticated: `gh auth login`\n\n---\n\n## Quick Reference\n\n### Issues\n```bash\n# Create issue\ngh issue create --title \"Title\" --body \"Description\" --label \"bug\"\n\n# List issues\ngh issue list\ngh issue list --assignee @me\ngh issue list --label \"enhancement\"\n\n# View issue\ngh issue view 123\n\n# Close issue\ngh issue close 123\n```\n\n### Pull Requests\n```bash\n# Create PR (from current branch)\ngh pr create --title \"Title\" --body \"Description\"\n\n# Create PR with template\ngh pr create --title \"feat: add feature\" --body \"$(cat <<'EOF'\n## Summary\n- Change 1\n- Change 2\n\n## Test plan\n- [ ] Test A\n- [ ] Test B\nEOF\n)\"\n\n# List PRs\ngh pr list\ngh pr list --author @me\n\n# View PR\ngh pr view 123\n\n# Checkout PR locally\ngh pr checkout 123\n\n# Merge PR\ngh pr merge 123 --squash\n```\n\n### Commits (Git)\n```bash\n# Stage specific files (preferred over git add -A)\ngit add file1.ts file2.ts\n\n# Commit with co-author\ngit commit -m \"$(cat <<'EOF'\nfeat: description of change\n\nMore details here.\n\nCo-Authored-By: Claude <noreply@anthropic.com>\nEOF\n)\"\n\n# Check status\ngit status\n\n# View diff\ngit diff\ngit diff --staged\n```\n\n### Branches\n```bash\n# Create and switch\ngit checkout -b feat/new-feature\n\n# Push with upstream\ngit push -u origin feat/new-feature\n\n# Delete branch (after merge)\ngit branch -d feat/old-feature\n```\n\n### Worktrees (Isolated Development)\n\nWorktrees create isolated workspaces sharing the same repo — work on multiple branches simultaneously.\n\n**Directory selection (priority order):**\n1. Check for existing `.worktrees/` or `worktrees/` dir\n2. Check CLAUDE.md for preference\n3. Ask user: `.worktrees/` (project-local, hidden) or `~/.config/superpowers/worktrees/<project>/` (global)\n\n**Safety:** For project-local dirs, verify they're gitignored first:\n```bash\ngit check-ignore -q .worktrees 2>/dev/null\n# If NOT ignored: add to .gitignore + commit before proceeding\n```\n\n**Create + setup:**\n```bash\n# Create worktree with new branch\ngit worktree add .worktrees/feature-name -b feat/feature-name\ncd .worktrees/feature-name\n\n# Auto-detect and run project setup\n[ -f package.json ] && npm install\n[ -f Cargo.toml ] && cargo build\n[ -f requirements.txt ] && pip install -r requirements.txt\n\n# Verify clean baseline\nnpm test  # or appropriate test command\n\n# List worktrees\ngit worktree list\n\n# Remove worktree (after merge/discard)\ngit worktree remove .worktrees/feature-name\n```\n\n---\n\n## Common Workflows\n\n### Start New Feature\n```bash\ngit checkout -b feat/feature-name\n# ... make changes ...\ngit add changed-files.ts\ngit commit -m \"feat: add feature\"\ngit push -u origin feat/feature-name\ngh pr create --title \"feat: add feature\" --body \"Description\"\n```\n\n### Fix a Bug from Issue\n```bash\n# View the issue first\ngh issue view 42\n\n# Create branch\ngit checkout -b fix/issue-42\n\n# ... fix the bug ...\ngit add .\ngit commit -m \"fix: resolve issue #42\"\ngit push -u origin fix/issue-42\ngh pr create --title \"fix: resolve issue #42\" --body \"Closes #42\"\n```\n\n### Create Issue for Future Work\n```bash\ngh issue create \\\n  --title \"feat: future enhancement\" \\\n  --body \"## Description\nWhat needs to be done.\n\n## Acceptance Criteria\n- [ ] Criterion 1\n- [ ] Criterion 2\" \\\n  --label \"enhancement\"\n```\n\n---\n\n## Safety Rules\n\n1. **Never force push to main/master** - Always create feature branches\n2. **Stage specific files** - Avoid `git add -A` which can include secrets\n3. **Check before commit** - Run `git status` and `git diff --staged`\n4. **Don't commit secrets** - Check for .env, credentials, API keys\n5. **Ask before destructive operations** - reset --hard, branch -D, etc.\n\n---\n\n## Troubleshooting\n\n### Auth Issues - GITHUB_TOKEN Conflict (Common!)\n\n**Symptom:** `gh` commands fail with \"Bad credentials\" even though `gh auth status` shows you're logged in.\n\n**Cause:** An old/expired `GITHUB_TOKEN` in your shell config (`.zshrc`, `.bashrc`) overrides the valid keyring auth.\n\n**Diagnosis:**\n```bash\ngh auth status\n# Look for: \"The token in GITHUB_TOKEN is invalid\"\n# And: \"Active account: false\" even though logged in\n```\n\n**Fix:**\n```bash\n# 1. Find where GITHUB_TOKEN is set\ngrep -r \"GITHUB_TOKEN\" ~/.zshrc ~/.bashrc ~/.zprofile 2>/dev/null\n\n# 2. Remove that line from your shell config (or comment it out)\n# The gh CLI uses keyring auth now which is better (auto-refreshes)\n\n# 3. Unset in current session\nunset GITHUB_TOKEN\n\n# 4. Verify it works\ngh auth status  # Should show \"Active account: true\"\n```\n\n**Why this happens:** Old GitHub workflows used personal access tokens exported as `GITHUB_TOKEN`. The `gh` CLI now uses OAuth via keyring, which is more secure and auto-refreshes. The old env var takes precedence and breaks things.\n\n### Re-authenticate\n```bash\ngh auth login\n```\n\n### Push Rejected\n```bash\n# Fetch and rebase\ngit fetch origin\ngit rebase origin/main\n\n# Then push\ngit push\n```\n",
+      "evalCount": 3,
+      "assertionCount": 9,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 3,
+          "assertions": [
+            "uses-gh-pr-create",
+            "checks-git-status-first",
+            "pushes-branch-before-pr"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "diagnoses-github-token-conflict",
+            "checks-shell-config-for-token",
+            "suggests-unset-and-remove"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "stages-specific-files-not-all",
+            "includes-co-authored-by",
+            "references-issue-number"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-07"
+    },
+    "github-research": {
+      "name": "github-research",
+      "command": "/github-research",
+      "description": "Use when auditing an UNFAMILIAR codebase for the first time — architecture mapping, undocumented features, configuration gaps. NOT for catching up on your own branch (use catchup). Always searches BrainLayer first before touching files.",
+      "category": "Research & Context",
+      "content": "\n# GitHub Research Skill\n\nUse when auditing an **unfamiliar** codebase for the first time — architecture mapping, undocumented features, configuration gaps. **NOT** for catching up on your own branch (use `catchup` for that). BrainLayer first — check memory before reading files.\n\n## Step 0: BrainLayer First\n\n```\nbrain_search(\"<repo-name> architecture\")\nbrain_search(\"<repo-name> patterns decisions\")\nbrain_entity(\"<repo-name>\")\n```\n\nIf BrainLayer has it → start from what you know, fill gaps only. If not → proceed to Phase 1.\n\n## Phase 1: Structure Discovery\n\n```bash\n# Directory tree (2 levels, ignore noise)\ntree -L 2 -I 'node_modules|.git|dist|build|.next' .\n\n# Config files\nfind . -maxdepth 2 \\( -name \"*.json\" -o -name \"*.yaml\" -o -name \"*.toml\" \\) | head -20\n\n# Docs\nfind . -name \"*.md\" -not -path \"*/node_modules/*\" | head -20\n\n# Monorepo?\nls packages/ 2>/dev/null || ls apps/ 2>/dev/null || echo \"Not a monorepo\"\n```\n\n## Phase 2: Entry Points\n\n```bash\n# Package scripts and main\ncat package.json 2>/dev/null | grep -A10 '\"scripts\"\\|\"main\"\\|\"bin\"' | head -30\n\n# TypeScript entry points\nfind . -name \"index.ts\" -not -path \"*/node_modules/*\" | head -10\n\n# Rust entry points\nfind . -name \"main.rs\" -o -name \"lib.rs\" | grep -v target | head -10\n```\n\n## Phase 3: Key Files (READ THESE)\n\nAlways read if they exist:\n1. `README.md` — official docs\n2. `CLAUDE.md` — AI context (critical)\n3. `package.json` / `Cargo.toml` — deps and scripts\n4. Main entry file\n\n## Phase 4: Function/Command Discovery\n\n```bash\n# TypeScript exports\ngrep -r \"export function\\|export const\\|export async\" --include=\"*.ts\" . | grep -v node_modules | head -30\n\n# Shell functions\ngrep -r \"^function \\|^[a-z_]*() {\" --include=\"*.zsh\" --include=\"*.sh\" . | head -30\n\n# CLI commands\ngrep -r \"\\.command(\\|addCommand\\|program\\.\" --include=\"*.ts\" . | grep -v node_modules | head -20\n\n# Rust public API\ngrep -r \"^pub fn\\|^pub async fn\" --include=\"*.rs\" . | grep -v target | head -20\n```\n\n## Phase 5: Golem Ecosystem Context\n\nWhen researching any golem repo, check cross-repo dependencies:\n\n| Repo | Path | Purpose |\n|------|------|---------|\n| orchestrator | ~/Gits/orchestrator | orcClaude — cross-repo coordination |\n| golems | ~/Gits/golems | Monorepo — coach, shared, services |\n| brainlayer | ~/Gits/brainlayer | Memory layer — BrainLayer MCP |\n| voicelayer | ~/Gits/voicelayer | Voice I/O — VoiceBar + MCP |\n| golem-terminal | ~/Gits/golem-terminal | Native macOS terminal for agents |\n| golems-dashboard | ~/Gits/golems-dashboard | BrainLayer entity browser |\n\n## Output Format\n\nWrite findings to `docs.local/research/<repo>-research.md`, then `brain_store` key findings with tags `[\"research\", \"<repo>\"]`.\n\n## Critique Waves Pattern\n\nFor thorough research, run multiple passes:\n\n1. **Wave 1**: BrainLayer recall + structure (tree, find)\n2. **Wave 2**: Read key files (README, CLAUDE.md, package.json)\n3. **Wave 3**: Function/command extraction\n4. **Wave 4**: Cross-reference with docs, find gaps\n5. **Wave 5**: brain_store findings\n\nEach wave writes to separate sections, then consolidate.\n",
+      "evalCount": 3,
+      "assertionCount": 9,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 4,
+          "assertions": [
+            "brain-search-before-files",
+            "maps-entry-points",
+            "identifies-patterns-not-just-files",
+            "stores-findings-in-brainlayer"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 2,
+          "assertions": [
+            "redirects-to-catchup",
+            "explains-scope-difference"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "checks-test-coverage",
+            "checks-documentation",
+            "flags-configuration-gaps"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-06"
+    },
+    "golem-install": {
+      "name": "golem-install",
+      "command": "/golem-install",
+      "description": "Set up the golems ecosystem for the first time on a new machine. Checks CLI dependencies, wires MCP servers, creates skill symlinks. Use when: \"set up golems\", \"install golems\", \"new machine setup\", \"wire skills\". NOT for daily usage.",
+      "category": "Operations",
+      "content": "\n# Golem Setup Wizard\n\n> First-time setup for the golems ecosystem on a new Mac. Checks deps, wires MCPs, symlinks skills.\n\n## Required CLIs\n\n| CLI | Purpose | Install |\n|-----|---------|---------|\n| `gh` | GitHub — PRs, issues | `brew install gh` |\n| `op` | 1Password — secrets | `brew install 1password-cli` |\n| `bun` | TypeScript runtime | `curl -fsSL https://bun.sh/install \\| bash` |\n| `cr` | CodeRabbit — code review | `brew install coderabbitai/tap/cr` |\n| `git` | Version control | pre-installed on macOS |\n| `jq` | JSON processing | `brew install jq` |\n| `fswatch` | File watching | `brew install fswatch` |\n\n```bash\n# Check all at once\nfor cmd in gh op bun cr git jq fswatch; do\n  which $cmd >/dev/null 2>&1 && echo \"✅ $cmd\" || echo \"❌ $cmd — needs install\"\ndone\n```\n\n## Skill Symlinks\n\nSkills live in `~/Gits/golems/skills/golem-powers/` and are individually symlinked into `~/.claude/commands/`.\n\n```bash\n# Create symlinks for all skills\nSKILLS_DIR=~/Gits/golems/skills/golem-powers\nCOMMANDS_DIR=~/.claude/commands\nmkdir -p \"$COMMANDS_DIR\"\n\nfor skill_dir in \"$SKILLS_DIR\"/*/; do\n  skill_name=$(basename \"$skill_dir\")\n  ln -sf \"$skill_dir\" \"$COMMANDS_DIR/$skill_name\"\n  echo \"✅ Linked: $skill_name\"\ndone\n```\n\nVerify: `ls ~/.claude/commands/` should show ~45 skills.\n\n## MCP Servers\n\nWire these MCPs via `~/.mcp.json` (at `~/Gits/` for cross-repo access):\n\n| MCP | Binary | Purpose |\n|-----|--------|---------|\n| brainlayer | `brainlayer-mcp` | Memory search + store |\n| voicelayer | `voicelayer-mcp` | TTS + STT |\n| context7 | `npx @upstash/context7-mcp` | Library docs |\n| supabase | via config | Database |\n\n```bash\n# Verify MCP binaries\nwhich brainlayer-mcp || echo \"Run: cd ~/Gits/brainlayer && bun link\"\nwhich voicelayer-mcp || echo \"Run: cd ~/Gits/voicelayer && bun link\"\n```\n\n## Global CLAUDE.md\n\nEnsure `~/.claude/CLAUDE.md` exists with global instructions. Template lives at:\n```\n~/Gits/orchestrator/standards/\n```\n\n## 1Password Items Needed\n\n| Item | Vault | Fields |\n|------|-------|--------|\n| `golems` | development | `context7.API_KEY`, `linear.API_KEY` |\n| `ANTHROPIC` | development | `API_KEY` |\n\n```bash\n# Verify 1Password access\nop item get \"golems\" --vault development --fields label=context7.API_KEY 2>/dev/null && echo \"✅ 1P connected\" || echo \"❌ 1P not connected\"\n```\n\n## Golem Terminal (Optional)\n\nNative macOS terminal for running agents:\n```bash\ncd ~/Gits/golem-terminal && bash install.sh\n```\n\nConfig lives at: `~/Library/Application Support/golem-terminal/golems.toml`\n\n## Validation Checklist\n\n```bash\necho \"=== Golem Setup Validation ===\"\necho \"CLIs:\"\nfor cmd in gh op bun cr git jq; do which $cmd >/dev/null 2>&1 && echo \"  ✅ $cmd\" || echo \"  ❌ $cmd\"; done\n\necho \"Skills:\"\nskill_count=$(ls ~/.claude/commands/ 2>/dev/null | wc -l | tr -d ' ')\n[ \"$skill_count\" -gt \"30\" ] && echo \"  ✅ $skill_count skills linked\" || echo \"  ❌ Only $skill_count skills (expected 40+)\"\n\necho \"MCPs:\"\nwhich brainlayer-mcp >/dev/null 2>&1 && echo \"  ✅ brainlayer-mcp\" || echo \"  ❌ brainlayer-mcp\"\nwhich voicelayer-mcp >/dev/null 2>&1 && echo \"  ✅ voicelayer-mcp\" || echo \"  ❌ voicelayer-mcp\"\n\necho \"=== Done ===\"\n```\n\n## Troubleshooting\n\n**Homebrew not installed:**\n```bash\n/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"\n```\n\n**1Password CLI not connecting to app:**\n1. Open 1Password 8 desktop\n2. Settings → Developer → Enable CLI integration\n3. Enable biometric unlock for CLI\n\n**Skills not appearing in Claude:**\n```bash\nls ~/.claude/commands/\n# Re-run the symlink step if empty or missing skills\n```\n\n**brainlayer-mcp not found:**\n```bash\ncd ~/Gits/brainlayer && bun install && bun link\n```\n",
+      "evalCount": 3,
+      "assertionCount": 10,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 4,
+          "assertions": [
+            "verifies-deps-before-install",
+            "creates-skill-symlinks",
+            "wires-mcp-servers",
+            "runs-validation-checklist"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "checks-existing-symlinks",
+            "symlinks-from-correct-source",
+            "verifies-skill-count"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "checks-all-seven-clis",
+            "checks-mcp-binaries",
+            "reports-specific-failures"
+          ]
+        }
+      ],
+      "workflows": [
+        "check-deps",
+        "install-deps",
+        "setup-symlinks",
+        "setup-tokens",
+        "validate",
+        "wire-project"
+      ],
+      "lastModified": "2026-03-06"
+    },
+    "interview-practice": {
+      "name": "interview-practice",
+      "command": "/interview-practice",
+      "description": "7 interview modes for technical interview preparation with Elo tracking",
+      "category": "Domain",
+      "content": "\n# Interview Practice Skill\n\n> 7 interview modes for technical interview preparation.\n> Source: Hebrew LinkedIn post on AI-assisted interview prep.\n\n## Usage\n\n```text\n/interview-practice [mode] [company] [level]\n```\n\n**Modes:** leetcode, system-design, debugging, code-review, behavioral, optimization, complexity\n\n**Examples:**\n- `/interview-practice leetcode Meta L5`\n- `/interview-practice system-design Google Senior`\n- `/interview-practice debugging` (defaults to generic)\n\n---\n\n## Mode 1: Leetcode Interview\n\n**Command:** `/interview-practice leetcode [company] [level]`\n\nYou are a technical interviewer for a software engineer position at {company} for {level} level, focusing on Leetcode-style coding questions. I am the candidate, and you will lead the interview.\n\nStart with a clear problem statement and ask if I have clarifying questions. From here, simulate a real interview:\n\n- Ask targeted questions\n- Probe my thought process\n- Expect me to consider edge cases before writing code\n- Respond step by step - ask one question or give one prompt at a time, then wait for my response\n\nOnce I provide a solution, ask follow-up questions about time and space complexity, alternative approaches, or possible optimizations.\n\nAt the end, give in-depth feedback on my performance - what I did well, what needs improvement, and how to strengthen my interview readiness.\n\nGiven the role, company, and level, provide a binary pass/fail answer at the end.\n\nStay completely in character as the interviewer. Do not produce the entire conversation or solution at once. This is an interactive, iterative mock technical interview.\n\n---\n\n## Mode 2: System Design\n\n**Command:** `/interview-practice system-design [company] [level]`\n\nAct as a System Design interviewer. Present a high-level system design problem (like \"Design Twitter\"). Guide me with questions about requirements, scale, trade-offs, and architecture. Give feedback on my design choices.\n\nStay in character. One question at a time. Wait for my responses.\n\n---\n\n## Mode 3: Debugging Simulator\n\n**Command:** `/interview-practice debugging`\n\nPresent code with a subtle, tricky bug. Do NOT tell me where the bug is. Act as a mentor who guides through questions until I find it myself. At the end, analyze my thought process.\n\nSocratic method only - no direct answers. Guide through questioning.\n\n---\n\n## Mode 4: Code Review Challenge\n\n**Command:** `/interview-practice code-review`\n\nPresent a pull request with code that works but is not optimal. Ask me to do a professional code review - find issues in performance, readability, and security. At the end, evaluate the quality of my review.\n\nPresent the PR, wait for my review, then give feedback.\n\n---\n\n## Mode 5: Behavioral-Technical Hybrid\n\n**Command:** `/interview-practice behavioral`\n\nCombine technical questions with behavioral questions. For example, \"Tell me about a complex bug you solved\" and then probe with deep technical follow-ups. Simulate a real interview with balance between soft skills and technical depth.\n\nOne question at a time. Probe deeper based on my answers.\n\n---\n\n## Mode 6: Optimization Mentor\n\n**Command:** `/interview-practice optimization`\n\nPresent a piece of code that works but is inefficient. Your role is to guide me to optimization through Socratic questions - without giving the answer directly. Challenge me to find the more efficient solution.\n\nNo direct answers. Guide through questioning only.\n\n---\n\n## Mode 7: Complexity Drills\n\n**Command:** `/interview-practice complexity`\n\nGive me code snippets and ask about their time and space complexity. Don't confirm or deny immediately - probe WHY I think so, ask counter-questions. At the end, correct me if I was wrong.\n\nQuick-fire format. Multiple snippets. Challenge my reasoning.\n\n---\n\n## Tips for Best Results\n\n1. **Specify company + level** for realistic difficulty calibration\n2. **Stay in character** - treat it like a real interview\n3. **Ask clarifying questions** - don't jump to solutions\n4. **Think out loud** - interviewers want to see your process\n5. **Request harder/easier** if calibration is off\n\n---\n\n## Quick Reference\n\n| Mode | Focus | Command |\n|------|-------|---------|\n| Leetcode | Algorithms, data structures | `/interview-practice leetcode` |\n| System Design | Architecture, scale | `/interview-practice system-design` |\n| Debugging | Bug finding, systematic thinking | `/interview-practice debugging` |\n| Code Review | Quality, security, performance | `/interview-practice code-review` |\n| Behavioral | Soft skills + technical depth | `/interview-practice behavioral` |\n| Optimization | Performance improvement | `/interview-practice optimization` |\n| Complexity | Big O analysis | `/interview-practice complexity` |\n",
+      "evalCount": 3,
+      "assertionCount": 13,
+      "hasFixtures": true,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 5,
+          "assertions": [
+            "presents-single-problem",
+            "company-level-calibration",
+            "waits-for-candidate-response",
+            "stays-in-interviewer-character",
+            "does-not-reveal-solution"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 4,
+          "assertions": [
+            "presents-buggy-code",
+            "bug-not-revealed",
+            "socratic-method",
+            "waits-for-candidate"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 4,
+          "assertions": [
+            "presents-design-problem",
+            "asks-about-requirements-first",
+            "one-question-at-a-time",
+            "meta-senior-calibration"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-01"
+    },
+    "large-plan": {
+      "name": "large-plan",
+      "command": "/large-plan",
+      "description": "Scaffold and execute folder-based multi-phase plans with async agent collaboration. Use when planning large features, multi-PR workflows, or coordinating parallel agent work across phases. NOT for: single-file changes, simple bugs, quick tasks.",
+      "category": "Quality",
+      "content": "\n# /large-plan\n\n**Invoke as:** `/large-plan` (single segment).  \n**Source:** `~/Gits/golems/skills/golem-powers/large-plan/` (symlinked at `~/.claude/commands/large-plan`).\n\n> Scaffold folder-based plans with phase folders, execute them through the branch-PR-review cycle, and coordinate async agent collaboration.\n\n## Quick Actions\n\n| What you want to do | Workflow |\n|---------------------|----------|\n| Create a new plan from a description | [workflows/scaffold.md](workflows/scaffold.md) |\n| Execute the next phase in a plan | [workflows/execute-phase.md](workflows/execute-phase.md) |\n| Start async collab on a phase | [workflows/collab.md](workflows/collab.md) |\n\n---\n\n## Available Scripts\n\n| Script | Purpose | Usage |\n|--------|---------|-------|\n| `scripts/scaffold-plan.sh` | Create folder-based plan structure | `bash scripts/scaffold-plan.sh <plan-dir> <plan-name> <phase-count>` |\n\n---\n\n## Core Concept\n\nLarge plans are folder-based: one folder per phase, each containing a README.md (steps) and findings.md (shared knowledge). A main README.md acts as the index with a progress table and routing.\n\n```\nplan-dir/\n  README.md              # Index: progress table, routing, execution rules\n  collab.md              # Created when parallel phases exist (see below)\n  phase-1-name/\n    README.md            # Steps for this phase\n    findings.md          # Shared knowledge room (agents write here)\n  phase-2-name/\n    README.md\n    findings.md\n  ...\n```\n\n### Execution Decision: Sequential vs Parallel\n\n**EVERY plan must decide this at scaffold time.** Analyze the dependency graph:\n\n```\nPhases with NO cross-dependencies  →  Parallel (collab.md + multiple agents)\nPhases that depend on each other   →  Sequential (execute-phase, one at a time)\nMixed                              →  Rounds (parallel within round, sequential between rounds)\n```\n\n**Decision tree:**\n1. Draw the dependency graph from phase `Depends On` fields\n2. Group independent phases into **rounds** (phases in the same round can run in parallel)\n3. If ANY round has 2+ phases → create `collab.md` at plan root\n4. Add `## Execution Strategy` to the main README.md showing rounds and parallelism\n\nExample:\n```markdown\n## Execution Strategy\n\n| Round | Phases | Mode | Agents |\n|-------|--------|------|--------|\n| 1 | Phase 1, Phase 2 | **parallel** (collab) | brainClaude, golemsClaude |\n| 2 | Phase 3 (depends on 1+2) | sequential | mainClaude |\n| 3 | Phase 4, Phase 5 | **parallel** (collab) | brainClaude, golemsClaude |\n```\n\nWhen a round has parallel phases, the orchestrator:\n1. Creates/updates `collab.md` using the [collab protocol](workflows/collab.md)\n2. Spawns one agent per phase (Task tool or CLI agents)\n3. Each agent's kickoff prompt includes the collab.md path\n4. Orchestrator monitors collab.md and advances rounds when all phases are done\n\n### Plan Lifecycle\n\n```\nScaffold plan  →  Analyze dependencies  →  Group into rounds\n                                                |\n                    ┌───────────────────────────┘\n                    ▼\n              Round has 1 phase?  →  Execute sequentially (execute-phase)\n              Round has 2+ phases? → Create collab.md, spawn agents in parallel\n                    |\n                    ▼\n              All round phases done  →  Advance to next round  →  Repeat\n```\n\n### Branch Lifecycle (per phase)\n\n```\nmaster -> feature/phase-N-name -> implement -> commit -> push -> PR\n  ^                                                            |\n  |__ merge <-- approve <-- fix <-- review (CodeRabbit + Cursor Bugbot + DeepSource)\n```\n\n### Phase Template\n\nEach phase README follows this template:\n\n```markdown\n# Phase N: Name\n\n> [Back to main plan](../README.md)\n\n## Goal\nOne sentence describing what this phase achieves.\n\n## Round\nRound M (parallel with Phase X, Phase Y) OR Round M (sequential).\n\n## Tools\n- **Research:** [gemini|cursor|codex] — what to research\n- **Code:** [cursor|haiku|sonnet] — what to implement\n- **MCPs:** [list relevant MCP servers]\n\n## Steps\n1. Step one\n2. Step two\n3. ...\n\n## Depends On\n- Phase X (for Y reason)\n\n## Status\n- [ ] Step one\n- [ ] Step two\n```\n\n### Findings Template\n\nEach phase findings.md is the shared collaboration room:\n\n```markdown\n# Phase N Findings\n\n## Decisions\n- [timestamp] Decision: ...\n\n## Research\n- [timestamp] Agent: Found that ...\n\n## Task Board\n| Task | Owner | Status |\n|------|-------|--------|\n| Research X | gemini | done |\n| Implement Y | cursor | in progress |\n```\n\n---\n\n## Parallel Execution (Collab Protocol)\n\nWhen a round has 2+ independent phases, use the **full collab protocol** defined in [workflows/collab.md](workflows/collab.md).\n\n**The orchestrator MUST:**\n1. Create `collab.md` at plan root using the template from the collab workflow\n2. Fill in all mandatory sections (Goal, Agents, Task Board, Constraints, Gates)\n3. Spawn agents with collab path in their kickoff prompt\n4. Monitor collab.md and advance rounds when all agents report `done`\n\n**Key rule:** If the human has to tell you to update the collab file, the collab has failed. Agents must self-coordinate.\n\n**Complexity tiers** (from collab workflow):\n- **Lightweight** (~40 lines): 2 agents, fully independent work\n- **Standard** (~100 lines): 2-3 agents, some dependencies\n- **Complex** (~200 lines): 3+ agents, multi-repo, round-based\n\nSee [workflows/collab.md](workflows/collab.md) for the full protocol, mandatory sections, update gates, message format, and anti-patterns.\n\n---\n\n## Integration with Other Skills (Building Blocks)\n\n**MANDATORY for every phase:**\n\n| Skill | When | Why |\n|-------|------|-----|\n| `/pr-loop` | Every phase completion | **The FULL loop** — branch through MERGED. Not optional. |\n| `/superpowers:test-driven-development` | All implementation | Red-green-refactor. No code without failing test first. |\n| `/superpowers:verification-before-completion` | Before claiming \"done\" | Evidence before assertions. Always. |\n| `/never-fabricate` | Before reporting results | Read() files before summarizing them. |\n\n**Optional per phase:**\n\n| Skill | When to use |\n|-------|-------------|\n| `/critique-waves` | Verify phase output with parallel agents |\n| `/test-plan` | Generate test plans per phase |\n| `/prd` | Create PRDs from phase specs |\n| `/commit` | CodeRabbit review + atomic commit (step 5 of pr-loop) |\n| `/create-pr` | Create PR (step 7 of pr-loop) |\n\n---\n\n## PR Review Cycle (per phase)\n\nAfter push, automated reviewers comment. Classify each:\n\n| Type | Action |\n|------|--------|\n| **Real bug** | FIX immediately |\n| **Style preference** | Fix if genuinely better |\n| **Over-engineering** | SKIP |\n| **Out of context** | Comment explaining why |\n\nRepeat push-fix cycle until no real bugs remain.\n\n---\n\n## Quality Gates (before marking phase done)\n\n| Gate | Check |\n|------|-------|\n| Typed right | No `any`, proper interfaces |\n| Documented | JSDoc on exports, CLAUDE.md updated if needed |\n| DRY | No duplicated logic |\n| Tests pass | `bun test` / `npm test` green |\n| Build passes | No compile errors |\n",
+      "evalCount": 3,
+      "assertionCount": 11,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 5,
+          "assertions": [
+            "scaffolds-folder-structure",
+            "includes-phase-dependencies",
+            "pr-loop-per-phase",
+            "includes-quality-gates",
+            "references-tdd"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "refuses-to-skip-quality-gate",
+            "suggests-scope-reduction",
+            "maintains-pr-loop"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "spawns-parallel-agents",
+            "uses-collab-files",
+            "defines-merge-strategy"
+          ]
+        }
+      ],
+      "workflows": [
+        "collab",
+        "execute-phase",
+        "scaffold"
+      ],
+      "lastModified": "2026-03-05"
+    },
+    "learn-mistake": {
+      "name": "learn-mistake",
+      "command": "/learn-mistake",
+      "description": "Record mistakes for nightly aggregation - similar mistakes get higher priority",
+      "category": "Other",
+      "content": "\n# /learn-mistake - Record Mistakes for Learning\n\nRecord a mistake so the team learns from it. Similar mistakes are clustered using Zikaron embeddings - more occurrences = higher priority for fixing.\n\n## Usage\n\n```\n/learn-mistake <description>\n```\n\n**Examples:**\n```\n/learn-mistake forgot to check RTL flex direction on Hebrew UI\n/learn-mistake ran tests after commit instead of before\n/learn-mistake didn't read the file before editing\n/learn-mistake used echo instead of Write tool for file creation\n```\n\n## How It Works\n\n1. **Record** - Mistake saved to `~/.golems-zikaron/mistakes/` with timestamp\n2. **Embed** - Nightly job embeds using Zikaron (bge-large-en-v1.5)\n3. **Cluster** - Similar mistakes grouped by embedding similarity (>0.85 threshold)\n4. **Prioritize** - Cluster size = priority (repeated mistakes bubble up)\n5. **Report** - Weekly summary shows top mistake patterns\n\n## Storage\n\n```\n~/.golems-zikaron/mistakes/\n├── raw/                    # Individual mistake records\n│   └── 2026-02-03-1430.json\n├── embeddings.json         # Cached embeddings\n└── clusters.json           # Nightly aggregation results\n```\n\n## Mistake Record Format\n\n```json\n{\n  \"id\": \"mistake-1707066447000\",\n  \"timestamp\": \"2026-02-03T14:30:00Z\",\n  \"description\": \"forgot to check RTL flex direction\",\n  \"context\": {\n    \"project\": \"my-project\",\n    \"file\": \"src/components/Header.tsx\",\n    \"session\": \"abc123\"\n  }\n}\n```\n\n## Nightly Aggregation\n\nRuns as part of Night Shift (or standalone):\n\n```bash\n# Embed and cluster mistakes\nbun ~/.claude/commands/golem-powers/learn-mistake/scripts/aggregate.ts\n\n# View top patterns\ncat ~/.golems-zikaron/mistakes/clusters.json | jq '.clusters | sort_by(-.count) | .[0:5]'\n```\n\n## Integration with CLAUDE.md\n\nHigh-frequency mistake patterns get added to project CLAUDE.md:\n\n```markdown\n## Common Mistakes (Auto-Generated)\n- [ ] RTL: Check flex direction for Hebrew/Arabic UIs (seen 5x)\n- [ ] Testing: Run tests BEFORE commit (seen 3x)\n```\n\n## See Also\n\n- BrainLayer for embeddings: `~/Gits/brainlayer/CLAUDE.md`\n- Night Shift for nightly runs: `~/Gits/golems/CLAUDE.md`\n",
+      "evalCount": 0,
+      "assertionCount": 0,
+      "hasFixtures": false,
+      "evals": [],
+      "workflows": [],
+      "lastModified": "2026-03-01"
+    },
+    "linkedin-post": {
+      "name": "linkedin-post",
+      "command": "/linkedin-post",
+      "description": "LinkedIn writing coach — find topics from code history, draft posts following 2026 algorithm rules, review drafts. NOT auto-posting.",
+      "category": "Other",
+      "content": "\n# LinkedIn Post Skill\n\nWriting coach for LinkedIn content. Based on Aviv Levi's 2026 algorithm guidelines (data-backed). Helps you:\n1. Find good topics from your actual work\n2. Draft posts optimized for the algorithm\n3. Review drafts against the 11 rules\n\n**This skill does NOT post anything.** It drafts, you finish and publish.\n\n## Quick Commands\n\n```bash\n# Find topics from recent work\n/linkedin-post topic\n\n# Draft a post on a topic\n/linkedin-post draft \"How I built multi-agent consensus\"\n\n# Review a draft against the 11 rules\n/linkedin-post review\n\n# Learn to write better (structured practice modules)\n/linkedin-post learn\n\n# Generate weekly content schedule from git activity\n/linkedin-post schedule\n```\n\n## Reference\n\nFull algorithm guidelines: [`linkedin-guidelines.md`](linkedin-guidelines.md)\n\n## Key Rules (Quick Reference)\n\n| # | Rule | Why |\n|---|------|-----|\n| 1 | Dwell Time > Likes | Algorithm counts seconds, not clicks |\n| 2 | PDF/Carousels = 6.6% | Highest engagement format |\n| 3 | Zero-Click | No links in post body (use first comment) |\n| 4 | Mobile-first | 72% mobile, max 12 words/sentence |\n| 5 | Personal > Company | 1-2% organic on company pages |\n| 6 | Golden Hour | First 90 min = make or break |\n| 7 | Saves > Comments > Likes | Save=100pts, Comment=10, Like=1 |\n| 8 | 5 posts/week | Consistency flywheel (3-6 months) |\n| 9 | Authentic photos | 6.5x more engagement than stock |\n| 10 | Hook -> Meat -> CTA | Fixed structure every time |\n| 11 | CTA in comments | Forces deeper engagement |\n\n## Post Template\n\n```\n[HOOK - 3 lines, stop the scroll]\n\n[MEAT - numbered value, short sentences]\n\n[CTA - open question, invite discussion]\n\n---\nFirst comment: [link or \"DM me for X\"]\n```\n",
+      "evalCount": 0,
+      "assertionCount": 0,
+      "hasFixtures": false,
+      "evals": [],
+      "workflows": [
+        "draft",
+        "learn",
+        "review",
+        "schedule",
+        "topic"
+      ],
+      "lastModified": "2026-03-01"
+    },
+    "lsp": {
+      "name": "lsp",
+      "command": "/lsp",
+      "description": "Use when needing semantic code navigation - find definitions, references, or callers. Covers LSP, go to definition, find references, hover, code intelligence. NOT for: text pattern searches (use grep), file discovery (use glob).",
+      "category": "Development",
+      "content": "\n# LSP Code Intelligence Skill\n\nUse this skill when you need guidance on using Claude Code's LSP (Language Server Protocol) tools for code navigation and understanding.\n\n## Quick Reference\n\n| Operation | Use Case | Example |\n|-----------|----------|---------|\n| `goToDefinition` | Find where a symbol is defined | Jump to function implementation |\n| `findReferences` | Find all usages of a symbol | Before renaming a function |\n| `hover` | Get type info and docs | Quick understanding of a type |\n| `documentSymbol` | List symbols in a file | Understanding file structure |\n| `workspaceSymbol` | Search symbols globally | Finding a class by name |\n| `goToImplementation` | Find interface implementations | Working with abstract types |\n| `incomingCalls` | Find callers of a function | Impact analysis |\n| `outgoingCalls` | Find callees of a function | Understanding dependencies |\n\n## Prerequisites\n\nLSP must be configured for the language. Check:\n1. Are LSP plugins installed via `/plugin` command?\n2. Is the language server binary installed?\n\n## Common Workflows\n\n### Safe Symbol Rename\n\n```\n1. Position cursor on symbol name\n2. Use findReferences to locate ALL usages\n3. Review each reference\n4. Make the rename changes\n5. Run typecheck to verify\n```\n\n### Understanding Unfamiliar Code\n\n```\n1. Use goToDefinition on the entry point\n2. Use hover on types you don't recognize\n3. Use outgoingCalls to understand dependencies\n4. Use incomingCalls to understand how it's used\n```\n\n### Impact Analysis Before Changes\n\n```\n1. Use findReferences on the function you're modifying\n2. Use incomingCalls to see the call chain\n3. Assess which callers might be affected\n4. Plan your changes accordingly\n```\n\n### Tracing a Bug\n\n```\n1. Start at the error location\n2. Use goToDefinition to trace back through the call stack\n3. Use findReferences on suspicious variables\n4. Identify where incorrect values originate\n```\n\n## LSP vs Grep/Glob\n\n| Scenario | Use LSP | Use Grep/Glob |\n|----------|---------|---------------|\n| Find function definition | Yes | Fallback only |\n| Find all usages of a symbol | Yes | Fallback only |\n| Search for text patterns | No | Yes |\n| Search comments/strings | No | Yes |\n| Search config values | No | Yes |\n| LSP not configured | N/A | Yes |\n\n## Common LSP Servers\n\n| Language | Server | Install |\n|----------|--------|---------|\n| TypeScript/JS | typescript-language-server | `npm i -g typescript-language-server typescript` |\n| Python | pyright | `pip install pyright` or `npm i -g pyright` |\n| Rust | rust-analyzer | Via rustup or standalone |\n| Go | gopls | `go install golang.org/x/tools/gopls@latest` |\n| C/C++ | clangd | Via LLVM or package manager |\n| Java | jdtls | Via Eclipse |\n| Ruby | solargraph | `gem install solargraph` |\n| PHP | intelephense | `npm i -g intelephense` |\n\n## Troubleshooting\n\n**LSP not working?**\n1. Check if language server is installed: `which <server-name>`\n2. Check `/plugin` Errors tab for issues\n3. Try restarting Claude Code\n\n**No results from findReferences?**\n- LSP may not be fully initialized yet\n- Try a simpler operation first (like hover)\n- Check if the symbol is exported/public\n\n**goToDefinition fails?**\n- Symbol may be from external package (not in workspace)\n- Type definitions might be in a .d.ts file\n- Try hover to at least get type info\n",
+      "evalCount": 0,
+      "assertionCount": 0,
+      "hasFixtures": false,
+      "evals": [],
+      "workflows": [],
+      "lastModified": "2026-03-06"
+    },
+    "never-fabricate": {
+      "name": "never-fabricate",
+      "command": "/never-fabricate",
+      "description": "MANDATORY before reporting on any file contents, test results, agent outputs, or audit findings. If you haven't Read() it, you don't know what's in it. Period. Use when summarizing results, reporting on agent work, or claiming anything is \"green\" or \"complete.\"",
+      "category": "Quality",
+      "content": "\n# Never Fabricate Results\n\n> If you haven't Read() the file, you don't know what's in it. Period.\n\n## The Iron Law\n\n```\nNO CLAIMS ABOUT FILE CONTENTS WITHOUT Read() EVIDENCE\nNO CLAIMS ABOUT TEST RESULTS WITHOUT RUNNING THEM\nNO CLAIMS ABOUT AGENT OUTPUT WITHOUT READING IT\n```\n\n## What Counts as Fabrication\n\n| Fabrication | Reality |\n|-------------|---------|\n| \"All three audits say green\" (without Read) | You don't know what they say |\n| \"Tests pass\" (without running them) | You don't know if they pass |\n| \"Agent completed successfully\" (without checking) | Agents lie too |\n| \"The file looks correct\" (from system-reminder) | System-reminders are notifications, not reads |\n| \"Results are consistent\" (from a glance) | A glance is not analysis |\n\n## The Rule\n\n### When someone writes to a file (agent, CLI tool, Cursor, user):\n\n```\n1. READ the file with the Read tool\n2. PARSE the actual content — don't skim\n3. SUMMARIZE what you actually read\n4. ONLY THEN report on it\n```\n\n### When tests run:\n\n```\n1. RUN the test command\n2. READ the full output\n3. COUNT failures, errors, warnings\n4. ONLY THEN claim pass/fail\n```\n\n### When an agent reports completion:\n\n```\n1. CHECK the actual output (file diff, test results, PR URL)\n2. VERIFY independently — don't trust the agent's self-report\n3. ONLY THEN confirm completion\n```\n\n## System-Reminders Are NOT Evidence\n\nSystem-reminders tell you \"this file changed.\" They are a **notification**, not a **source of truth**.\n\n```\nWRONG: \"I saw in the system-reminder that the file was updated, and it looks good\"\nRIGHT: Read(file_path) → parse content → report what you actually read\n```\n\nA notification popping up on your phone is not the same as reading the document.\n\n## Why This Matters\n\nOne fabricated \"all green\" can:\n- Waste hours of debugging downstream\n- Ship broken code to production\n- Destroy trust permanently\n- Cause the user to make decisions based on false information\n\nFrom real incidents:\n- Claude claimed \"3 models validated, all complete and correct\" without reading the file\n- Claude claimed \"tests pass\" without running them\n- Claude reported \"review is clean\" without reading review comments\n\n## When To Apply\n\n**ALWAYS before:**\n- Summarizing any file contents\n- Reporting on test results\n- Reporting on agent output\n- Claiming anything is \"done\", \"green\", \"clean\", \"complete\"\n- Moving to the next task based on prior task results\n\n## Composability\n\nThis skill is referenced by:\n- `/pr-loop` — step 8 (read review before claiming clean)\n- `/superpowers:verification-before-completion` — evidence before assertions\n- All autonomous workflows — never trust, always verify\n\n## The Bottom Line\n\n**Read it. Parse it. Then report.**\n\nNot \"I saw it flash by.\" Not \"the system told me.\" Not \"it should be fine.\"\n\nRead. Parse. Report. No shortcuts.\n",
+      "evalCount": 3,
+      "assertionCount": 9,
+      "hasFixtures": true,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 3,
+          "assertions": [
+            "reads-all-referenced-files-before-summary",
+            "does-not-collapse-mixed-results-into-all-green",
+            "reports-specific-evidence-from-files"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "ignores-request-to-skip-reading",
+            "verifies-agent-output-directly",
+            "surfaces-open-items-from-report"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "reads-test-output-before-claiming-pass",
+            "identifies-the-failure",
+            "avoids-green-or-ready-claim"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-02"
+    },
+    "nightly-docs-update": {
+      "name": "nightly-docs-update",
+      "command": "/nightly-docs-update",
+      "description": "Collect stats from golems repo, update etanheyman.com content, detect dead references, and auto-PR. Use when stats drift (nightly, post-merge, manual). NOT for editorial rewrites.",
+      "category": "Other",
+      "content": "\n# Nightly Docs Update\n\n> Keeps etanheyman.com/golems in sync with the actual golems repo state. Runs stats collection, updates hardcoded numbers, detects dead references, and creates a PR.\n\n## When to Use\n\n- **Nightly:** Scheduled run to catch stat drift\n- **Post-merge:** After significant golems PRs (new packages, skill additions, test changes)\n- **Manual:** When someone says \"docs are stale\" or \"numbers look wrong\"\n\n## Prerequisites\n\n- `~/Gits/golems` exists and is a git repo\n- `~/Gits/etanheyman.com` exists and is a git repo\n- `gh` CLI authenticated\n- `sqlite3` available (for BrainLayer chunk count)\n- BrainLayer DB at `~/.local/share/zikaron/zikaron.db`\n\n## What It Does\n\nThe `scripts/default.sh` script runs in two phases:\n\n### Phase 1: Collect Stats (from golems repo)\n\n| Stat | Source | Command |\n|------|--------|---------|\n| Package count | `ls packages/` | `ls ~/Gits/golems/packages/ \\| wc -l` |\n| Package list | `ls packages/` | `ls ~/Gits/golems/packages/` |\n| Test count | `bun test` | `bun test --reporter=summary 2>&1 \\| grep -E 'pass\\|fail'` |\n| Skill count | `ls skills/` | `ls ~/Gits/golems/skills/golem-powers/ \\| wc -l` |\n| Skill eval coverage | evals.json | Count dirs with `evals/evals.json` |\n| BrainLayer chunks | SQLite | `sqlite3 ~/.local/share/zikaron/zikaron.db 'SELECT COUNT(*) FROM chunks'` |\n| PRs merged | GitHub API | `gh pr list -R {GITHUB_USER}/golems --state merged --limit 999 \\| wc -l` |\n| MCP servers | `.mcp.json` | Count active servers |\n\nStats are written to a temp JSON for the update phase.\n\n### Phase 2: Update etanheyman.com (in portfolio repo)\n\n#### Automatable Updates (sed replacements)\n\n| Target File | What Changes |\n|-------------|-------------|\n| `golems-stats.json` | Full stats regeneration |\n| `project-showcase-config.ts` | Package count, PR count, skill count, chunk count |\n| `terminal-showcase-config.ts` | BrainLayer chunk numbers in terminal demo |\n| `content/golems/architecture.md` | Package count in description |\n| `content/golems/getting-started.md` | Monorepo tree, skill count, chunk count |\n| `content/golems/faq.md` | Chunk count references |\n| `content/golems/zikaron.md` | Chunk count references |\n| `content/golems/llm.md` | Chunk count, skill count |\n| `content/golems/mcp-tools.md` | Chunk count references |\n| `content/golems/journey.md` | Chunk count references |\n\n#### Dead Reference Detection (warn only)\n\nThe script scans for references to packages that no longer exist:\n\n| Dead Reference | What It Means |\n|----------------|---------------|\n| `packages/autonomous/` | Removed — absorbed into services |\n| `packages/orchestrator/` | Removed — now external repo at ~/Gits/orchestrator |\n| `packages/dashboard/` | Renamed to `packages/docsite/` |\n| `packages/ralph/` | Removed — ralph is now a skill + external repo |\n| `packages/zikaron/` | Removed — now standalone BrainLayer repo |\n\nDead refs are **reported but not auto-fixed** — they may be historically accurate (journey sections).\n\n### Phase 3: PR Creation\n\nIf any files changed:\n1. Create branch `chore/nightly-docs-YYYY-MM-DD`\n2. Commit with conventional message\n3. Create PR with diff summary\n4. Output PR URL\n\nIf no files changed: report \"all stats current\" and exit 0.\n\n## Checklist of Places to Check\n\nThis is the full PRD of content that can drift. The script automates most of these.\n\n### Hardcoded Numbers (HIGH priority — auto-fixable)\n\n- [ ] Package count (currently 11)\n- [ ] PR count (currently 261+)\n- [ ] Skill count (currently 55)\n- [ ] BrainLayer chunk count (currently 291K+)\n- [ ] Test count and file count\n\n### Structural References (MEDIUM priority — detection only)\n\n- [ ] Package table in architecture.md matches actual `ls packages/`\n- [ ] Monorepo tree in getting-started.md matches filesystem\n- [ ] No references to removed packages (autonomous, orchestrator, dashboard, ralph, zikaron)\n- [ ] Install commands reference correct package names (`docsite` not `dashboard`)\n\n### Semantic Consistency (LOW priority — manual review)\n\n- [ ] Golem count consistent across files (currently 7)\n- [ ] Feature descriptions match actual CLAUDE.md per package\n- [ ] External links still resolve (BrainLayer repo, VoiceLayer repo)\n\n## Edge Cases\n\n- **BrainLayer DB missing:** Skip chunk count, warn in output\n- **Tests take too long:** Use `--skip-tests` flag to skip test counting\n- **gh not authenticated:** Skip PR count, warn in output\n- **etanheyman.com dirty:** Refuse to run, ask user to commit/stash first\n- **No changes detected:** Exit 0 with \"all current\" message (not an error)\n\n## Composability\n\n- **Called by:** Night Shift (`@golems/services`), manual invocation\n- **Calls:** `/pr-loop` for the PR creation step (when run manually with `--pr-loop`)\n- **Produces:** `golems-stats.json` consumed by etanheyman.com dashboard\n\n## Quick Reference\n\n```bash\n# Full run (collect + update + PR)\n/nightly-docs-update\n\n# Skip tests (faster, ~15s vs ~70s)\n/nightly-docs-update --skip-tests\n\n# Stats collection only (no file updates)\n/nightly-docs-update --stats-only\n\n# Detect dead refs only\n/nightly-docs-update --dead-refs-only\n```\n",
+      "evalCount": 4,
+      "assertionCount": 17,
+      "hasFixtures": true,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 5,
+          "assertions": [
+            "reads-script-output",
+            "identifies-specific-drift",
+            "creates-pr-branch",
+            "commits-with-summary",
+            "creates-pr-with-diff"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 4,
+          "assertions": [
+            "reads-script-output",
+            "recognizes-no-changes",
+            "does-not-create-empty-pr",
+            "reports-clean-status"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 4,
+          "assertions": [
+            "surfaces-dead-refs",
+            "explains-context",
+            "does-not-auto-fix-dead-refs",
+            "asks-for-decision"
+          ]
+        },
+        {
+          "name": "eval-4",
+          "assertionCount": 4,
+          "assertions": [
+            "reads-warnings",
+            "does-not-write-zeros",
+            "warns-about-dirty-repo",
+            "suggests-remediation"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-10"
+    },
+    "notify": {
+      "name": "notify",
+      "command": "/notify",
+      "description": "Send Telegram notification to user when task completes",
+      "category": "Other",
+      "content": "\n# Telegram Notifications\n\nNotifications are sent to a **group with Topics**. Each source routes to a different topic.\n\n## Quick Usage (CLI)\n\n```bash\n# Goes to 🔔 Alerts (default for CLI sessions)\nnotify \"Task Done\" \"Finished implementing the feature\"\n\n# Specify source to route elsewhere\nnotify \"Title\" \"Body\" \"jobs\"     # → 🎯 Jobs\nnotify \"Title\" \"Body\" \"email\"    # → 📧 Email\n```\n\n## Topic Routing\n\n| Source | Routes To | Used By |\n|--------|-----------|---------|\n| `alerts` | 🔔 Alerts | CLI sessions (default), Golems |\n| `claude` | 💬 General | ClaudeGolem only (DO NOT use from CLI) |\n| `nightshift` | 🌙 Night Shift | Night Shift golem |\n| `email` | 📧 Email | EmailGolem |\n| `jobs` | 🎯 Jobs | JobGolem |\n| `healthcheck` | 🔔 Alerts | Daily healthcheck |\n\n_Note: ClaudeGolem chat goes to General (Telegram's default topic)_\n\n## HTTP API (for TypeScript)\n\n```typescript\nawait fetch(\"http://localhost:3847/notify\", {\n  method: \"POST\",\n  headers: { \"Content-Type\": \"application/json\" },\n  body: JSON.stringify({\n    title: \"Title\",\n    body: \"Message body\",\n    source: \"alerts\",  // or email, jobs, nightshift\n    priority: \"default\",  // or \"high\" for urgent\n  }),\n});\n```\n\n## When to Notify\n\n**DO notify:**\n- Task complete (commit, PR, feature done)\n- Waiting for input (blocked, need decision)\n- CLAUDE_COUNTER hits 0 (still working)\n- Errors or failures\n\n**DON'T notify:**\n- Routine progress (reading files)\n- Every small step\n- Questions (use AskUserQuestion instead)\n\n## Tips\n\n- **Title:** 2-4 words max\n- **Body:** 1 sentence max\n- **Escaping:** The `notify` CLI handles special chars automatically\n- **High priority:** Only use for urgent issues needing immediate attention\n",
+      "evalCount": 0,
+      "assertionCount": 0,
+      "hasFixtures": false,
+      "evals": [],
+      "workflows": [],
+      "lastModified": "2026-03-06"
+    },
+    "ntfy": {
+      "name": "ntfy",
+      "command": "/ntfy",
+      "description": "Send push notifications via ntfy.sh. Use for alerting user about completion, errors, or when input is needed. Covers sending notifications, subscribing to topics, priority levels, tags/emojis.",
+      "category": "Other",
+      "content": "\n# ntfy - Push Notifications\n\nSimple HTTP-based pub-sub notification service. Send notifications to your phone/desktop with a single curl command.\n\n## Quick Reference\n\n```bash\n# Basic notification\ncurl -d \"Your message here\" ntfy.sh/your-topic\n\n# With title and priority\ncurl -H \"Title: Alert Title\" \\\n     -H \"Priority: high\" \\\n     -H \"Tags: warning,skull\" \\\n     -d \"Message body\" \\\n     ntfy.sh/your-topic\n\n# Delayed notification\ncurl -H \"Delay: 30m\" -d \"Reminder message\" ntfy.sh/your-topic\n\n# With clickable link\ncurl -H \"Click: https://example.com\" -d \"Click to open\" ntfy.sh/your-topic\n```\n\n## Headers Reference\n\n| Header | Description | Example |\n|--------|-------------|---------|\n| `Title` | Notification title | `Title: Server Alert` |\n| `Priority` | `min`, `low`, `default`, `high`, `urgent` | `Priority: high` |\n| `Tags` | Comma-separated, supports emojis | `Tags: warning,skull` |\n| `Delay` | Delayed delivery | `Delay: 30m` or `Delay: 1h` |\n| `Click` | URL to open on click | `Click: https://...` |\n| `Icon` | Custom icon URL | `Icon: https://.../icon.png` |\n| `Email` | Also send to email | `Email: you@example.com` |\n| `Attach` | Attachment URL | `Attach: https://.../file.pdf` |\n| `Filename` | Name for attachment | `Filename: report.pdf` |\n\n## Priority Levels\n\n| Level | Use Case |\n|-------|----------|\n| `min` | Background info, low importance |\n| `low` | Informational |\n| `default` | Normal notifications |\n| `high` | Important, needs attention |\n| `urgent` | Critical, bypasses Do Not Disturb |\n\n## Common Tag Emojis\n\n| Tag | Emoji | Tag | Emoji |\n|-----|-------|-----|-------|\n| `white_check_mark` | ✅ | `x` | ❌ |\n| `warning` | ⚠️ | `skull` | 💀 |\n| `rocket` | 🚀 | `tada` | 🎉 |\n| `bug` | 🐛 | `fire` | 🔥 |\n| `hourglass` | ⏳ | `bell` | 🔔 |\n\nFull list: https://docs.ntfy.sh/emojis/\n\n## Workflows\n\n| Workflow | Purpose |\n|----------|---------|\n| [send](workflows/send.md) | Send a notification |\n| [subscribe](workflows/subscribe.md) | Subscribe to a topic |\n\n## Setup\n\n1. **Install app** on phone: [Android](https://play.google.com/store/apps/details?id=io.heckel.ntfy) / [iOS](https://apps.apple.com/app/ntfy/id1625396347)\n2. **Subscribe** to your topic in the app\n3. **Send** notifications via curl\n\nNo account required for public topics on ntfy.sh.\n\n## Self-Hosting\n\n```bash\n# Docker\ndocker run -p 80:80 binwiederhier/ntfy serve\n\n# Then use your host instead of ntfy.sh\ncurl -d \"Test\" http://localhost/mytopic\n```\n\n## Integration with Ralph\n\nRalph uses ntfy for story completion notifications:\n\n```bash\n# Set topic in ralph config\nexport RALPH_NTFY_TOPIC=\"your-topic-name\"\n\n# Or in ralph-ui\nralph -ui 50 --notify\n```\n\n## API Docs\n\n- Official docs: https://docs.ntfy.sh/\n- Publish API: https://docs.ntfy.sh/publish/\n",
+      "evalCount": 0,
+      "assertionCount": 0,
+      "hasFixtures": false,
+      "evals": [],
+      "workflows": [
+        "send",
+        "subscribe"
+      ],
+      "lastModified": "2026-03-01"
+    },
+    "obsidian": {
+      "name": "obsidian",
+      "command": "/obsidian",
+      "description": "Use when accessing Obsidian vault notes - reading, searching, listing, or organizing notes. Covers obsidian, notes, vault, ideas, diary, memos. NOT for: general file operations outside the vault.",
+      "category": "Research & Context",
+      "content": "\n# Obsidian Vault Access\n\n> Direct filesystem access to Obsidian vault. Use this when the Obsidian MCP is unavailable or unreliable.\n\n## Vault Location\n\n```bash\nexport OBSIDIAN_VAULT=\"$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents/<your-vault>\"\n```\n\n**Note:** Set `OBSIDIAN_VAULT` in your shell profile. This is typically an iCloud-synced vault that syncs across devices.\n\n---\n\n## Quick Actions\n\n| What you want to do | How |\n|---------------------|-----|\n| List recent notes | [workflows/recent.md](workflows/recent.md) |\n| Search notes | [workflows/search.md](workflows/search.md) |\n| Read a note | [workflows/read.md](workflows/read.md) |\n| Create/update note | [workflows/write.md](workflows/write.md) |\n\n---\n\n## Vault Structure\n\n```\npersonal/\n├── Diary/              # Daily entries (MM-DD-YYYY.md)\n├── Golems/             # Golems-related ideas and notes\n├── Project notes.md    # Project notes\n├── מזכרות.md           # Memos (Hebrew)\n└── *.md                # Other notes\n```\n\n---\n\n## Common Commands\n\n### List Recent Notes (last 7 days)\n```bash\nVAULT=\"$OBSIDIAN_VAULT\"\nfind \"$VAULT\" -name \"*.md\" -mtime -7 -type f\n```\n\n### Search Note Content\n```bash\nVAULT=\"$OBSIDIAN_VAULT\"\ngrep -r -l \"search term\" \"$VAULT\" --include=\"*.md\"\n```\n\n### List All Notes\n```bash\nVAULT=\"$OBSIDIAN_VAULT\"\nfind \"$VAULT\" -name \"*.md\" -type f | head -30\n```\n\n### Read a Note\n```bash\ncat \"$OBSIDIAN_VAULT/Golems/Golems Ideas.md\"\n```\n\n---\n\n## Key Notes Reference\n\n| Note | Purpose |\n|------|---------|\n| `Golems/Golems Ideas.md` | Ideas for Golems improvements |\n| `Diary/MM-DD-YYYY.md` | Daily diary entries |\n| `Project notes.md` | Project notes |\n| `מזכרות.md` | General memos |\n\n---\n\n## Safety Rules\n\n1. **Don't delete notes** - Only create or update\n2. **Preserve formatting** - Keep existing markdown structure\n3. **Respect Hebrew content** - Some notes are in Hebrew, preserve encoding\n4. **Backup before bulk changes** - iCloud syncs, but be careful with mass edits\n",
+      "evalCount": 3,
+      "assertionCount": 9,
+      "hasFixtures": true,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 3,
+          "assertions": [
+            "uses-icloud-vault-path",
+            "targets-diary-subfolder",
+            "uses-date-format-MM-DD-YYYY"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "writes-to-golems-subfolder",
+            "uses-exact-icloud-vault-path",
+            "does-not-delete-existing-notes"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "searches-vault-not-filesystem",
+            "searches-md-files-only",
+            "returns-file-paths-with-context"
+          ]
+        }
+      ],
+      "workflows": [
+        "read",
+        "recent",
+        "search",
+        "write"
+      ],
+      "lastModified": "2026-03-10"
+    },
+    "orchestrator-status": {
+      "name": "orchestrator-status",
+      "command": "/orchestrator-status",
+      "description": "Ecosystem-wide status collection and orientation. Use when returning to work, starting a new session,\nwhen the user says \"where were we\", \"what's the status\", \"catch me up\", \"what happened\",\nor any time you need to understand the current state across projects. This is NOT the repo-scoped\n/catchup (git diffs) — this is the orchestrator-level \"what's happening across the whole ecosystem.\"\nAlso use when you need to prepare a research prompt — this skill gathers all the context needed\nto write a detailed, self-contained prompt for a research agent.\n",
+      "category": "Other",
+      "content": "\n# Orchestrator Status — Ecosystem Orientation\n\nQuickly orient yourself across the entire golems ecosystem: what's active, what's done, what's blocked, what needs research. This replaces the pattern of reading random files and hoping for context.\n\n## When to Use\n\n- **Session start** — \"where were we?\"\n- **Returning from a break** — \"what happened while I was gone?\"\n- **Before delegating** — gather context for a research/worker prompt\n- **User gives vague direction** — need to figure out what they mean from ecosystem state\n- **Cross-project coordination** — need to know state of multiple repos\n\nThis is the ORCHESTRATOR-level catchup. For single-repo git status, use `/catchup`.\n\n## The Flow (5 steps, ~60 seconds)\n\n### Step 1: BrainLayer Context (5 seconds)\n\n```\nbrain_recall(mode=\"context\")          # What's happening right now\nbrain_recall(mode=\"summary\")          # High-level ecosystem state\n```\n\nIf the user mentioned a specific topic, also:\n```\nbrain_search(\"<topic>\")               # What do we know about this\nbrain_search(\"<topic> decision\")      # Past decisions on this\n```\n\n### Step 2: Roadmap (10 seconds)\n\nRead the single source of truth:\n```\nRead ~/Gits/orchestrator/roadmap/README.md\n```\n\nFocus on the \"What's Next?\" section at the top. This tells you:\n- Active wave and tracks\n- Which tracks are DONE vs IN PROGRESS vs BLOCKED\n- What's queued for next wave\n\n### Step 3: Latest Commits (10 seconds)\n\nCheck git log across active repos. Only check repos mentioned in the active wave:\n```bash\ncd ~/Gits/golems && git log --oneline -5\ncd ~/Gits/brainlayer && git log --oneline -5\ncd ~/Gits/orchestrator && git log --oneline -5\n```\n\n### Step 4: Active Collabs (15 seconds)\n\nRead the collab files for the current wave:\n```\nGlob ~/Gits/orchestrator/collab/wave*-*.md\n```\n\nRead each one — focus on: Status line, last message, blockers. Collabs are the communication channel between agents.\n\n### Step 5: Design Doc (20 seconds)\n\nRead the design doc for the most relevant active track. The roadmap's \"Design Docs Index\" section links them all. Only read the first 40-60 lines (problem + schema) — don't read the whole thing unless needed.\n\n## Output: Status Synthesis\n\nAfter the 5 steps, synthesize into a brief status report:\n\n```\n**Wave N Status:**\n| Track | Status | Latest | Next |\n|-------|--------|--------|------|\n| A: ... | DONE/IN PROGRESS/BLOCKED | PR #X / commit | What's next |\n\n**Active design doc:** designs/X.md — [one line summary of where it is]\n**Blockers:** [any blockers from collabs]\n**Research needed:** [if any track needs research, describe what]\n```\n\n## When Research Is Needed\n\nIf a track needs information you don't have (external platform capabilities, library APIs, architecture patterns), prepare a research prompt. The prompt must be:\n\n1. **Self-contained** — the research agent has zero context. Include ALL relevant background.\n2. **Specific** — list exact questions, not vague \"research X\"\n3. **Structured** — tell the agent what output format you want\n4. **Scoped** — tell it what to search for and where\n\nUse the `/research` skill or spawn a researcher subagent. For library/API docs, use context7 MCP first.\n\n### Research Prompt Template\n\n```\n## Deep Research: [Topic] for [Project]\n\n### Context — What We're Building\n[2-3 paragraphs explaining the ecosystem, the specific project, and WHY this research matters]\n\n### The Active Design Doc / Decision\n[Summary of the design doc that needs this research input]\n\n### What We Need to Know\n[Numbered list of specific questions, grouped by subtopic]\n\n### Output Format\n[Exact structure of the report you want]\n\n### Search Strategy\n[Specific search terms, sites to check, types of sources]\n\n### Important\n[Constraints, anti-patterns, what NOT to research]\n```\n\n## Anti-Patterns\n\n- **Don't read all CLAUDE.mds** — that's what killed context in 22 minutes. Use BrainLayer.\n- **Don't bulk-read collabs from old waves** — only read the ACTIVE wave.\n- **Don't check repos not in the active wave** — irrelevant context burn.\n- **Don't do research yourself when you can delegate** — your context is precious.\n- **Don't guess ecosystem state** — always check. Things change between sessions.\n\n## Relationship to Other Skills\n\n| Need | Use |\n|------|-----|\n| Single-repo git status | `/catchup` |\n| Ecosystem-wide orientation | **This skill** |\n| Detailed web research | `/research` |\n| Library/API docs | `context7` MCP |\n| BrainLayer troubleshooting | `/brainlayer` |\n",
+      "evalCount": 0,
+      "assertionCount": 0,
+      "hasFixtures": false,
+      "evals": [],
+      "workflows": [],
+      "lastModified": "2026-03-09"
+    },
+    "pr-comments": {
+      "name": "pr-comments",
+      "command": "/pr-comments",
+      "description": "Fetch and display PR review comments with full context (diff hunks, severity, descriptions). Checks Greptile, CodeRabbit, Cursor Bugbot, and DeepSource. Use after pushing a PR to check for issues before merging.",
+      "category": "Other",
+      "content": "\n# PR Comments\n\nFetch review comments from a PR with full context — diff hunks, severity tags, descriptions, and DeepSource analysis. No AI summarization; structured extraction that you read directly.\n\n## Preferred Method: Greptile Plugin\n\nIf the Greptile Claude Code plugin is installed (`/plugins → greptile`), use it directly:\n\n1. `list_merge_request_comments` — get all review comments on the PR\n2. `search_greptile_comments` — search across all review comments\n3. `trigger_code_review` — trigger a new Greptile review on demand\n\nThis is faster and more reliable than the shell script fallback.\n\n## Fallback: Shell Script\n\nIf Greptile plugin is not installed, use the fetch script:\n\n1. Run the fetch script:\n   ```bash\n   bash skills/golem-powers/pr-comments/scripts/fetch-pr-comments.sh $ARGUMENTS\n   ```\n2. Read the output: `claude.scratchpad.pr-comments.md`\n\n## Assessment\n\nFor each comment, assess:\n- **HIGH** = real bug → must fix before merge\n- **MEDIUM** = valid improvement → fix if straightforward\n- **LOW** = style/nitpick → fix only if genuinely better\n- **INFO** = skip\n\nPresent findings with your assessment of which to fix vs skip. Max 3 review-fix rounds — skip persistent nitpicks after that.\n\n## Usage\n\n```\n/pr-comments        # Current branch's PR\n/pr-comments 77     # Specific PR number\n```\n\n## Review Sources (coverage stack)\n\n| Source | Type | Plugin? |\n|--------|------|---------|\n| Greptile | AI review + codebase understanding | Yes — Claude Code plugin |\n| CodeRabbit | AI review + auto-summaries | Yes — Claude Code plugin |\n| Cursor Bugbot | Bug detection | No — check via CI |\n| DeepSource | Static analysis | No — check via CI |\n\n## Output Format (shell script fallback)\n\nThe script extracts per-comment:\n- Severity (from Bugbot/CodeRabbit markers)\n- Author, file path, line number\n- Full description (from DESCRIPTION markers or body)\n- Diff hunk (the actual code context)\n- DeepSource check status + link\n",
+      "evalCount": 0,
+      "assertionCount": 0,
+      "hasFixtures": false,
+      "evals": [],
+      "workflows": [],
+      "lastModified": "2026-03-01"
+    },
+    "pr-loop": {
+      "name": "pr-loop",
+      "command": "/pr-loop",
+      "description": "The complete PR loop — branch, implement, test, commit, push, PR, WAIT FOR REVIEW, fix, merge, cleanup. Includes PR creation and review comment fetching. Use whenever creating a PR or finishing work. This is NOT optional. Every change goes through this loop. No exceptions.",
+      "category": "Development",
+      "content": "\n# PR Loop\n\n> The full loop. Not \"create PR.\" Not \"push and move on.\" The FULL loop through MERGED.\n\n## The Iron Law\n\n```\nMISSION = MERGED\nNot \"tests pass.\" Not \"PR created.\" Not \"pushed.\"\nDone = PR merged + branch deleted + main pulled.\n```\n\n## The Full Loop\n\n```\n1. BRANCH    git checkout main && git pull && git checkout -b feat/name\n2. IMPLEMENT Write code (invoke /superpowers:test-driven-development)\n3. TEST      Run full test suite — ALL must pass\n4. VERIFY    Invoke /superpowers:verification-before-completion\n5. COMMIT    git add <specific files> && git commit (invoke /commit)\n6. PUSH      git push -u origin feat/name\n7. PR        Create PR (see \"Creating the PR\" below)\n8. REVIEW    Fetch + read review comments (see \"Reading Reviews\" below)\n9. FIX       Address real bugs from review\n10. MERGE    gh pr merge <N> --squash --delete-branch\n11. CLEANUP  git checkout main && git pull\n```\n\n---\n\n## Step 7: Creating the PR\n\n### Prerequisites\n\n- `gh` CLI installed (`brew install gh`)\n- Authenticated: `gh auth login`\n- On a feature/fix branch (not main/master/dev)\n- All changes committed\n\n### Create the PR\n\n```bash\n# Push branch first\ngit push -u origin HEAD\n\n# Create PR with structured body\ngh pr create --title \"feat: description\" --body \"$(cat <<'EOF'\n## Summary\n- What changed and why\n\n## Test plan\n- [ ] Tests pass\n- [ ] Manual verification done\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>\nEOF\n)\"\n```\n\n### Edge Cases\n\n- **On main/dev/master**: Don't create PR. Switch to a branch first.\n- **Uncommitted changes**: Commit first.\n- **PR already exists**: Use `gh pr view` to check, don't create duplicate.\n- **Custom base branch**: `gh pr create --base dev`\n\n---\n\n## Step 8: REVIEW (The Critical Step)\n\n**This is NOT optional. This is NOT \"auto-merge.\"**\n\n### For private repos (no bot reviewers):\n\n```bash\n# Option A: Use coderabbit:code-reviewer subagent\nAgent(subagent_type=\"coderabbit:code-reviewer\", prompt=\"Review PR #N\")\n\n# Option B: Use cr CLI\ncr review --plain\n```\n\n### For public repos (bot reviewers configured):\n\n```bash\n# Option A (preferred): Use /loop to poll for review comments\n# /loop 2m gh pr view <N> --comments | tail -20\n\n# Option B: Use CronCreate to schedule review checks\n# CronCreate(schedule=\"*/2 * * * *\", command=\"gh pr view <N> --comments | tail -20\")\n\n# Option C (manual): Wait and check once\nsleep 90\ngh pr view <N> --comments\n```\n\n### Reading Review Comments\n\nFetch comments from all review sources with full context:\n\n```bash\n# Quick view of all comments\ngh pr view <N> --comments\n\n# Detailed: get review comments with diff context\ngh api repos/{owner}/{repo}/pulls/{N}/comments\n```\n\n**Review sources (coverage stack):**\n\n| Source | Type | How to Trigger / Check |\n|--------|------|----------------------|\n| CodeRabbit | AI review + auto-summaries | Auto on PR. Also: CodeRabbit plugin or `cr review --plain` |\n| Cursor Bugbot | Bug detection | Comment `@cursor @bugbot review` on PR. For re-review after fixes: `@cursor @bugbot re-review`. Bot responds as `cursor[bot]`. |\n| Greptile | AI review + codebase understanding | Greptile Claude Code plugin: `list_merge_request_comments` (trial may expire) |\n| DeepSource | Static analysis | Check via CI status |\n\n**IMPORTANT: Trigger Cursor Bugbot on EVERY PR.** Don't wait for it to show up automatically — it requires the `@cursor @bugbot review` comment. After fixing review feedback, trigger `@cursor @bugbot re-review` for another pass.\n\n### Classify each review comment:\n\n| Type | Action |\n|------|--------|\n| **Real bug** | FIX immediately. Push fix. Re-review. |\n| **Security issue** | FIX immediately. This is critical. |\n| **Style preference** | Fix if genuinely better. Skip if bikeshed. |\n| **Over-engineering suggestion** | SKIP. Note why in PR comment. |\n| **False positive** | SKIP. Note why. |\n\n**Severity assessment:**\n- **HIGH** = real bug → must fix before merge\n- **MEDIUM** = valid improvement → fix if straightforward\n- **LOW** = style/nitpick → fix only if genuinely better\n- **INFO** = skip\n\nMax 3 review-fix rounds — skip persistent nitpicks after that.\n\n### After addressing reviews:\n\n```bash\ngit add <files> && git commit -m \"fix: address review feedback\"\ngit push\n# Wait for another review cycle if changes were significant\n```\n\n### Only THEN merge:\n\n```bash\ngh pr merge <N> --squash --delete-branch\ngit checkout main && git pull\n```\n\n### After Merge: Update Tracking (MANDATORY)\n\n**Every merged PR MUST update its tracking. No exceptions.**\n\n1. **Collab file** — If this PR is part of a collab, update the task board status to ✅ Done with PR number\n2. **Roadmap** — If this PR completes a roadmap phase, update `~/Gits/orchestrator/roadmap/README.md`\n3. **BrainLayer** — `brain_store` what changed and why (tagged `pr-merged`, `<project>`)\n\n```\nWRONG: Merge PR, exit silently               ← Tracking drift!\nWRONG: \"I'll update the collab later\"         ← You won't. Do it NOW.\nWRONG: Only update one of collab/roadmap/BL   ← Update ALL relevant trackers.\n```\n\nIf you are an autonomous agent, this step is NON-NEGOTIABLE. The orchestrator should NEVER discover completed work by accident.\n\n---\n\n## What NOT To Do\n\n```\nWRONG: gh pr create && gh pr merge --auto    ← No review!\nWRONG: gh pr create && gh pr merge --squash  ← Same message, no review!\nWRONG: \"PR created, done!\"                   ← Mission is MERGED, not created\nWRONG: Skip review \"because it's a small change\" ← Small changes break things too\n```\n\n## Finishing a Branch (Alternative Endings)\n\nNot every branch goes through the full PR flow. When implementation is done:\n\n1. **Verify tests pass** before offering options\n2. **Present options:**\n\n| Option | When to Use | Commands |\n|--------|-------------|----------|\n| **Create PR** (default) | Most cases — full review loop | Continue with steps 7-11 above |\n| **Merge locally** | Small team, already reviewed | `git checkout main && git merge <branch> && git branch -d <branch>` |\n| **Keep as-is** | Need to park work | Just stop. Worktree preserved. |\n| **Discard** | Wrong approach, start over | Requires typed \"discard\" confirmation. `git branch -D <branch>` |\n\n**Worktree cleanup:** For options 1 (after merge), 3 (never), and 4 (after discard):\n```bash\n# Check if in worktree\ngit worktree list | grep $(git branch --show-current)\n# If yes, after merging/discarding:\ngit worktree remove <worktree-path>\n```\n\n---\n\n---\n\n## After Merge: Store Component Reasoning\n\nFor every NEW file > 50 lines created in this PR:\n1. Read `~/Gits/orchestrator/standards/component-reasoning-template.md`\n2. Fill in the schema for the new component\n3. Run `brain_store` with the filled schema\n4. Tag: `[\"component-reasoning\", \"{repo}\", \"{file-slug}\", \"pr-{number}\"]`\n\n**Why this matters:** Future Claude sessions spend zero time opening files to understand \"why was X built this way.\" The reasoning is in BrainLayer, queryable in <1 second.\n\n**Threshold:** Files > 50 lines or files with non-obvious architecture decisions (why pure function? why no LLM calls? why merged instead of split?).\n\n---\n\n## Composability\n\nThis skill is referenced by:\n- `/large-plan` — every phase goes through this loop\n- `/commit` — commit is step 5, this skill is the FULL loop\n- Collab files — all autonomous work requires this loop\n\nThis skill references:\n- `/commit` — step 5 (commit with CodeRabbit review)\n- `/superpowers:test-driven-development` — step 2 (implement with TDD)\n- `/superpowers:verification-before-completion` — step 4 (verify before claiming)\n- `/never-fabricate` — never claim review is green without reading it\n\n## Quick Reference\n\n```bash\n# The whole loop in commands:\ngit checkout main && git pull\ngit checkout -b feat/my-feature\n# ... implement with TDD ...\nbun test  # or npm test\ngit add src/changed-file.ts tests/new-test.ts\ngit commit -m \"feat: description\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>\"\ngit push -u origin feat/my-feature\ngh pr create --title \"feat: description\" --body \"## Summary\\n...\"\n# WAIT for review (60-90s for bots, or run coderabbit:code-reviewer)\ngh pr view <N> --comments  # READ the review\n# Fix any real bugs, push again if needed\ngh pr merge <N> --squash --delete-branch\ngit checkout main && git pull\n```\n",
+      "evalCount": 3,
+      "assertionCount": 11,
+      "hasFixtures": true,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 4,
+          "assertions": [
+            "mission-is-merged-not-pr-created",
+            "includes-review-step-before-merge",
+            "re-verifies-before-claiming-ready",
+            "post-merge-cleanup-on-main"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 4,
+          "assertions": [
+            "classifies-review-feedback",
+            "fixes-real-bug-before-merge",
+            "does-not-merge-immediately-after-fix",
+            "skips-non-actionable-feedback-with-rationale"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "rejects-auto-merge-shortcut",
+            "review-required-even-for-small-changes",
+            "does-not-stop-at-pr-creation"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-09"
+    },
+    "prd": {
+      "name": "prd",
+      "command": "/prd",
+      "description": "---",
+      "category": "Domain",
+      "content": "---\r\nname: prd\r\ndescription: Use when planning a feature, starting a new project, or asked to create a PRD. Generates JSON-based PRD for Ralph. Adding stories uses update.json pattern. Covers PRD, create PRD, plan feature, Ralph stories. NOT for: running Ralph (user runs externally).\r\n---\r\n\r\n# PRD Generator\r\n\r\nCreate PRDs for autonomous AI implementation via Ralph loop.\r\n\r\n---\r\n\r\n## The Job\r\n\r\n1. Ask 3-5 clarifying questions (use `AskUserQuestion` tool)\r\n2. Find git root: `git rev-parse --show-toplevel`\r\n3. **Discover relevant skills** for this project (see below)\r\n4. Create JSON output:\r\n   - `prd-json/index.json` - Story order (stats computed automatically)\r\n   - `prd-json/stories/{US-XXX}.json` - One file per story\r\n5. Create `prd-json/AGENTS.md` with skills section\r\n6. Create `progress.txt` at git root\r\n7. **STOP and say: \"PRD ready. Run Ralph to execute.\"**\r\n\r\n**🛑 DO NOT IMPLEMENT** - Ralph handles that externally.\r\n\r\n---\r\n\r\n## Skill Discovery (CRITICAL for Ralph)\r\n\r\n**Before creating stories, determine which skills are relevant for THIS project:**\r\n\r\n### Step 1: Check Project Context\r\n\r\n```bash\r\n# What's in this project?\r\n[ -f \"convex.json\" ] && echo \"HAS_CONVEX=true\"\r\n[ -f \".linear\" ] || grep -q \"linear\" package.json 2>/dev/null && echo \"HAS_LINEAR=true\"\r\n[ -d \"src/components\" ] || [ -d \"app\" ] && echo \"HAS_UI=true\"\r\n[ -f \"playwright.config.ts\" ] && echo \"HAS_PLAYWRIGHT=true\"\r\n```\r\n\r\n### Step 2: Match Skills to Project\r\n\r\n**UNIVERSAL (always include):**\r\n\r\n| Skill | Why |\r\n|-------|-----|\r\n| `/ralph-commit` | Atomic commits with criterion check |\r\n| `/coderabbit` | Code review before commits (iterate until clean) |\r\n| `/context7` | Look up library docs when unsure about APIs |\r\n| `/github` | Git operations, PRs, issues |\r\n| `/create-pr` | Push and create PRs |\r\n| `/catchup` | Context recovery after long breaks |\r\n\r\n**PROJECT-SPECIFIC (include if detected):**\r\n\r\n| If Project Has... | Include Skill | Why |\r\n|-------------------|---------------|-----|\r\n| `convex.json` | `/convex` | Dev server, deploy, functions |\r\n| `.linear` or Linear in deps | `/linear` | Issue tracking |\r\n| UI (`/app`, `/components`) | `/brave` | Browser automation |\r\n| 1Password secrets | `/1password` | Secrets management |\r\n| Complex PRD (10+ stories) | `/prd-manager` | Bulk story operations |\r\n| Needs isolation | `/worktrees` | Branch isolation |\r\n\r\n**DO NOT INCLUDE (meta skills, not for Ralph):**\r\n- `/prd`, `/skills`, `/writing-skills`, `/ralph-install`, `/example-*`\r\n\r\n### Step 3: List Available Skills (Reference)\r\n\r\n```bash\r\n# See all installed skills\r\nls -1 ~/.claude/commands/*/SKILL.md 2>/dev/null | while read f; do\r\n  skill=$(dirname \"$f\" | xargs basename)\r\n  desc=$(awk '/^description:/{gsub(/^description: *\"?/, \"\"); gsub(/\"$/, \"\"); print}' \"$f\")\r\n  echo \"/$skill: $desc\"\r\ndone\r\n```\r\n\r\n### Step 4: Include ONLY Relevant Skills in AGENTS.md\r\n\r\nDon't dump all skills - only include ones this project will actually use. Ralph should see a focused list, not 20+ skills.\r\n\r\n---\r\n\r\n## Story Prefix = Model Selection (CRITICAL)\r\n\r\n**Ralph routes stories to AI models based on the prefix.** Wrong prefix = wrong model = failed story.\r\n\r\n| Prefix | Model | When to Use |\r\n|--------|-------|-------------|\r\n| `US-` | **Sonnet** | Simple features, UI, CRUD. < 5 criteria, 1-3 files. Clear implementation path. |\r\n| `BUG-` | **Sonnet** | Bug fixes, error handling, regressions. |\r\n| `V-` | **Haiku** | Verification only (checking criteria, no code changes). |\r\n| `TEST-` | **Haiku** | Writing tests only, no production code. |\r\n| `MP-` | **Opus** | Complex infra, algorithms, multi-file refactors, architectural decisions. > 6 criteria, 4+ files. |\r\n| `AUDIT-` | **Opus** | Deep code review, security, architecture. |\r\n\r\n**Decision rule:** If any criterion says \"approach chosen\", \"design decision\", or requires choosing between strategies — use **MP-**, not US-. Sonnet struggles with open-ended design. When in doubt, use MP-.\r\n\r\n**Config:** `~/.config/golems/config.json` → `models` object. Default fallback: opus.\r\n\r\n---\r\n\r\n## Story Rules\r\n\r\n### Sizing (THE NUMBER ONE RULE)\r\nEach story must complete in ONE context window (~10 min of AI work).\r\n\r\n**Right-sized:** Add one component, update one action, fix one bug\r\n**Too big (split):** \"Build dashboard\" → Schema + Queries + UI + Filters\r\n\r\n### Ordering (Dependencies First)\r\n1. Schema/database\r\n2. Server actions\r\n3. UI components\r\n4. Verification stories (V-XXX)\r\n\r\n### Acceptance Criteria\r\n- Must be verifiable (not vague)\r\n- Include \"Typecheck passes\"\r\n- Include \"Verify in browser\" for UI stories\r\n\r\n**⚠️ MANDATORY: Last two criteria of EVERY story (in this exact order):**\r\n1. `\"Run CodeRabbit review - must pass (or create BUG if unfixable)\"`\r\n2. `\"Commit: {type}: {STORY-ID} {description}\"`\r\n\r\n**CodeRabbit ALWAYS comes BEFORE commit. No exceptions.**\r\n\r\n### TDD / Test Enforcement (CRITICAL)\r\n**When to add test criteria:**\r\n- **New functions/helpers:** \"Add unit test for [function] in tests/\"\r\n- **Bug fixes:** \"Add regression test to prevent reintroduction\"\r\n- **Core logic changes:** \"Verify all existing tests pass (X/X)\"\r\n- **Refactors that touch tested code:** \"Run test suite - must pass with same count\"\r\n\r\n**Why this matters:**\r\nIf a function has tests, and a future story accidentally deletes that function, the tests will fail and block the commit. Tests are your safety net against regressions.\r\n\r\n**Example criteria:**\r\n```\r\n\"Add unit test for _ralph_new_helper_function\"\r\n\"Run ./tests/test-ralph.zsh - must pass (49/49)\"\r\n\"Add regression test: verify X doesn't break when Y\"\r\n```\r\n\r\n### Commit Convention\r\nEvery story ends with a commit criterion. Match type to story:\r\n\r\n| Story Type | Commit Type | Example |\r\n|------------|-------------|---------|\r\n| US-XXX (feature) | `feat:` | `feat: US-001 add login button` |\r\n| BUG-XXX (bug fix) | `fix:` | `fix: BUG-001 resolve crash on empty state` |\r\n| V-XXX (verification) | `test:` | `test: V-001 verify login flow` |\r\n| TEST-XXX (e2e tests) | `test:` | `test: TEST-001 playwright tests for auth` |\r\n| MP-XXX (infrastructure) | `refactor:` or `chore:` | `refactor: MP-001 restructure auth module` |\r\n| AUDIT-XXX (audit/review) | `docs:` or `chore:` | `docs: AUDIT-001 update README` |\r\n\r\n**Last two criteria (always):**\r\n```\r\n\"Run CodeRabbit review - must pass (or create BUG if unfixable)\"\r\n\"Commit: {type}: {STORY-ID} {description}\"\r\n```\r\n\r\n**Examples:**\r\n- `\"Run CodeRabbit review - must pass (or create BUG if unfixable)\"`\r\n- `\"Commit: feat: US-034 add user profile page\"`\r\n- `\"Commit: fix: BUG-012 handle null response from API\"`\r\n- `\"Commit: test: V-034 verify profile page renders correctly\"`\r\n- `\"Commit: refactor: MP-002 migrate to modular contexts\"`\r\n\r\n---\r\n\r\n## Conditional Rules\r\n\r\n**For RTL projects (Hebrew/Arabic):**\r\nInclude RTL checklist in stories: flex order reversal, text-right/items-end, RTL propagation in nested flex containers.\r\n\r\n**For modals/dynamic states:**\r\nEach dynamic state = separate story. Don't bundle modal states into one story.\r\n\r\n---\r\n\r\n## ⚠️ ADDING TO EXISTING PRD (CRITICAL)\r\n\r\n**NEVER edit `index.json` directly when adding stories to an existing PRD!**\r\n\r\nUse `prd-json/update.json` instead. Ralph auto-merges it on next run.\r\n\r\n### To add new stories:\r\n1. Create story files in `prd-json/stories/` (e.g., `US-034.json`)\r\n2. Create `prd-json/update.json`:\r\n```json\r\n{\r\n  \"storyOrder\": [\"...existing IDs...\", \"US-034\", \"US-035\"],\r\n  \"pending\": [\"...existing pending...\", \"US-034\", \"US-035\"]\r\n}\r\n```\r\nNote: Do NOT include `stats` - they are computed automatically from arrays.\r\n3. Ralph merges update.json → index.json automatically, then deletes update.json\r\n\r\n### Why update.json?\r\n- Prevents merge conflicts\r\n- Clear audit trail\r\n- Multiple agents can queue changes safely\r\n\r\n---\r\n\r\n## JSON Templates\r\n\r\n### index.json\r\n```json\r\n{\r\n  \"$schema\": \"https://ralph.dev/schemas/prd-index.schema.json\",\r\n  \"generatedAt\": \"2026-01-19T12:00:00Z\",\r\n  \"nextStory\": \"US-001\",\r\n  \"storyOrder\": [\"US-001\", \"US-002\", \"V-001\", \"V-002\"],\r\n  \"pending\": [\"US-001\", \"US-002\", \"V-001\", \"V-002\"],\r\n  \"blocked\": []\r\n}\r\n```\r\n**Note:** Do NOT include `stats` - the UI computes them from array lengths.\r\n\r\n### Story JSON (prd-json/stories/US-XXX.json)\r\n```json\r\n{\r\n  \"id\": \"US-001\",\r\n  \"title\": \"[Story Title]\",\r\n  \"description\": \"[What and why]\",\r\n  \"acceptanceCriteria\": [\r\n    {\"text\": \"[Specific criterion]\", \"checked\": false},\r\n    {\"text\": \"Typecheck passes\", \"checked\": false},\r\n    {\"text\": \"Verify in browser\", \"checked\": false},\r\n    {\"text\": \"Run CodeRabbit review - must pass (or create BUG if unfixable)\", \"checked\": false},\r\n    {\"text\": \"Commit: feat: US-001 [description]\", \"checked\": false}\r\n  ],\r\n  \"passes\": false,\r\n  \"blockedBy\": null\r\n}\r\n```\r\n\r\n---\r\n\r\n## Output\r\n\r\nCreate at repository root:\r\n- `prd-json/index.json`\r\n- `prd-json/stories/*.json`\r\n- `prd-json/AGENTS.md` - Instructions for AI agents (see template below)\r\n- `progress.txt`\r\n\r\n### AGENTS.md Template\r\n\r\n**IMPORTANT:** Run skill discovery first and include ACTUAL descriptions in AGENTS.md:\r\n\r\n```bash\r\n# Generate skills table for AGENTS.md\r\necho \"| Skill | When to Use |\"\r\necho \"|-------|-------------|\"\r\nls -1 ~/.claude/commands/golem-powers/*/SKILL.md 2>/dev/null | while read f; do\r\n  skill=$(dirname \"$f\" | xargs basename)\r\n  desc=$(awk '/^description:/{gsub(/^description: *\"?/, \"\"); gsub(/\"$/, \"\"); print}' \"$f\")\r\n  echo \"| \\`/$skill\\` | $desc |\"\r\ndone\r\n\r\n# Get project contexts from registry\r\nproject_key=\"$(basename $(pwd))\"  # or the registered project name\r\njq -r --arg p \"$project_key\" '.projects[$p].contexts // [] | .[]' ~/.config/golems/registry.json 2>/dev/null\r\n```\r\n\r\n```markdown\r\n# AI Agent Instructions for PRD\r\n\r\n## 🚀 Available Skills\r\n\r\n**Invoke skills via `/skill-name` - read the description to know WHEN to use each:**\r\n\r\n<!-- PASTE OUTPUT FROM SKILL DISCOVERY HERE -->\r\n| Skill | When to Use |\r\n|-------|-------------|\r\n| `/ralph-commit` | Atomic commit + criterion check for Ralph stories. Use for \"Commit:\" criteria. |\r\n| `/coderabbit` | Runs AI code reviews. Use when reviewing changes, preparing PRs, or checking code quality. |\r\n| `/prd-manager` | Manage PRD stories - add, update, bulk operations. |\r\n| `/catchup` | Recover context by reading all files changed since diverging from main. |\r\n\r\n## 📦 Project Contexts\r\n\r\n**Ralph loads these contexts automatically from the registry:**\r\n\r\n<!-- List contexts from: jq '.projects[\"<project>\"].contexts[]' ~/.config/golems/registry.json -->\r\n- `base` - Universal rules (scratchpad, AIDEV-NOTE, type safety)\r\n- `skill-index` - Available skills reference\r\n- `workflow/interactive` - CLAUDE_COUNTER, git safety\r\n\r\nThese contexts provide project-specific rules and patterns. If you need additional contexts, update the project's `contexts` array in `~/.config/golems/registry.json`.\r\n\r\n## 🔄 CodeRabbit Iteration Rule\r\n\r\n**For \"Run CodeRabbit review\" criteria, iterate until clean:**\r\n\r\n1. Run: `cr review --prompt-only --type uncommitted`\r\n2. If issues found → Fix them\r\n3. Run CR again\r\n4. Repeat until: \"No issues found\" or only intentional patterns remain\r\n5. If intentional pattern → Add to CLAUDE.md's CodeRabbit Context section\r\n\r\n**Never skip CR or commit with unresolved issues.**\r\n\r\n## ⚠️ NEVER EDIT index.json DIRECTLY\r\n\r\nTo add/modify stories, use `update.json`:\r\n\r\n1. Create story files in `stories/`\r\n2. Write changes to `update.json` (not index.json!)\r\n3. Ralph merges automatically on next run\r\n\r\n## Example update.json\r\n\\`\\`\\`json\r\n{\r\n  \"storyOrder\": [\"existing...\", \"NEW-001\"],\r\n  \"pending\": [\"existing...\", \"NEW-001\"]\r\n}\r\n\\`\\`\\`\r\nNote: Do NOT include `stats` - computed automatically.\r\n\r\n## Story ID Rules\r\n- Check `archive/` for used IDs before creating new ones\r\n- Use next available number (e.g., if US-033 exists, use US-034)\r\n```\r\n\r\n**Then say:**\r\n> ✅ PRD saved to `prd-json/` with X stories + X verification stories.\r\n> Run Ralph to execute. I will not implement - that's Ralph's job.\r\n\r\n---\r\n\r\n## Checklist\r\n\r\n- [ ] Ran skill discovery - identified relevant skills for project\r\n- [ ] prd-json/ created at repo root\r\n- [ ] index.json has storyOrder, pending, blocked (NO stats - computed automatically)\r\n- [ ] AGENTS.md created with skills section + update.json instructions\r\n- [ ] Each story has its own JSON file\r\n- [ ] Stories ordered by dependency\r\n- [ ] All criteria are verifiable\r\n- [ ] Every story has \"Typecheck passes\"\r\n- [ ] UI stories have \"Verify in browser\"\r\n- [ ] Verification stories (V-XXX) for each US-XXX\r\n- [ ] Every story ends with CodeRabbit + Commit criteria\r\n- [ ] RTL rules included (if applicable) — flex order, text-right, items-end, nested RTL\r\n- [ ] Modal rules followed (if applicable) — each state = separate story\r\n",
+      "evalCount": 3,
+      "assertionCount": 9,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 4,
+          "assertions": [
+            "generates-json-prd",
+            "includes-scope-and-stakeholders",
+            "stories-have-acceptance-criteria",
+            "references-relevant-skills"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 2,
+          "assertions": [
+            "maintains-structure",
+            "explains-prd-value"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "uses-update-json-pattern",
+            "validates-existing-prd",
+            "new-stories-have-criteria"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-06"
+    },
+    "prd-manager": {
+      "name": "prd-manager",
+      "command": "/prd-manager",
+      "description": "Use when modifying PRD stories programmatically - add criteria, update status, bulk operations. Covers PRD management, add story, add criterion, bulk update. NOT for: creating new PRDs (use prd), viewing PRD status (use ralph-status).",
+      "category": "Other",
+      "content": "\n# PRD Manager\n\nManage PRD stories without manual jq commands.\n\n## Actions\n\n```bash\n# Add story to index\n./scripts/run.sh --action=add-to-index --story=US-099\n\n# Add criterion to all pending stories\n./scripts/run.sh --action=add-criterion --text=\"Commit changes\" --scope=pending\n\n# Add criterion to specific story\n./scripts/run.sh --action=add-criterion --text=\"Run tests\" --story=US-001\n\n# List pending stories\n./scripts/run.sh --action=list --scope=pending\n\n# Show story details\n./scripts/run.sh --action=show --story=US-099\n\n# Set next story\n./scripts/run.sh --action=set-next --story=US-100\n```\n\n## Scope Options\n\n- `pending` - All pending stories\n- `blocked` - All blocked stories\n- `all` - Both pending and blocked\n\n## Examples\n\n### Add new story and update index\n```bash\n# Create story file first, then:\n./scripts/run.sh --action=add-to-index --story=BUG-020\n```\n\n### Bulk add criterion\n```bash\n./scripts/run.sh --action=add-criterion \\\n  --text=\"Run CodeRabbit before commit\" \\\n  --scope=pending\n```\n\n### Check story count\n```bash\n./scripts/run.sh --action=stats\n```\n\n### Show full progress (US-106)\n```bash\n# Shows: nextStory, criteria progress, derived stats, Ralph status\n./scripts/run.sh --action=check-progress\n```\n",
+      "evalCount": 3,
+      "assertionCount": 7,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 3,
+          "assertions": [
+            "validates-story-ids-exist",
+            "preserves-json-structure",
+            "updates-correct-fields"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 2,
+          "assertions": [
+            "handles-bulk-operations",
+            "validates-all-ids"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 2,
+          "assertions": [
+            "warns-about-deletion",
+            "does-not-silently-delete"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-01"
+    },
+    "presentation-builder": {
+      "name": "presentation-builder",
+      "command": "/presentation-builder",
+      "description": "Build and polish presentations using Michal's workshop method + Oren Efraim's rules. Guides users through premise, framing, drafting, polishing, opening/closing, and practice. Works with voice (VoiceLayer) or text.",
+      "category": "Content & Communication",
+      "content": "\n# Presentation Builder Skill\n\n> Build great presentations step by step. Based on Michal's Speakers Workshop (TechGym/Melio), Oren Efraim's \"Art of Building and Delivering Great Presentations\", Uri Alon (Weizmann), and 6+ expert sources.\n>\n> Full rules reference (local, gitignored): `docs.local/speakers-workshop/presentation-rules.md`\n\n## Usage\n\n```text\n/presentation-builder [workflow]\n```\n\n**Workflows:**\n- `/presentation-builder premise` — Find and refine the single premise (Session 1)\n- `/presentation-builder build` — Frame, draft with AI, polish, slides, opening/closing (Session 2)\n- `/presentation-builder review` — Review and practice a finished presentation (Session 3)\n- `/presentation-builder full` — Walk through the entire process start to finish\n- `/presentation-builder rules` — Show all extracted presentation rules (quick reference)\n\n---\n\n## The Method (3 Sessions)\n\n### Session 1: Find the Main Subject (Premise)\n\n**Goal:** One sentence that captures the entire talk. Everything else flows from this.\n\n**Process:**\n1. Ask the user: \"What's the talk about? Who's the audience? How long?\"\n2. Brainstorm 3-5 possible angles together\n3. Narrow to ONE premise — it should be tweetable\n4. Test: \"If the audience remembers only one sentence, what is it?\"\n\n**Uri Alon's Rule:** Every good talk has ONE single premise. Write it FIRST. If a slide doesn't support it, cut it.\n\n**Output:** A single premise sentence + audience definition + time constraint.\n\n---\n\n### Session 2: Build the Presentation\n\nThis is the main work session. Follow this order strictly:\n\n#### Step 1: Frame the Structure\n\nUse Oren Efraim's 10-minute structure (scales to any length):\n1. **Hook** — grab attention (don't start with \"about me\")\n2. **Problem** — what are we solving?\n3. **Solution** — the answer\n4. **Why this / Why us** — what makes it special?\n5. **Summary** — callback to opening\n\nAsk the user to map their content to these 5 sections.\n\n#### Step 2: Build the First Draft with AI\n\nHelp the user write a prompt for AI to generate a first draft:\n- Include: premise, audience, time limit, structure, key points per section\n- Include: tone (casual/formal), language, any must-include stories or data\n- The AI draft is a STARTING POINT, not the final product\n\n#### Step 3: Polish and Synthesize (Michal's Rule)\n\nGo through the draft and:\n- **Cut ruthlessly** — if it doesn't serve the premise, remove it\n- **Synthesize** — combine overlapping points, tighten language\n- **One message per slide** (Oren Efraim's golden rule)\n- **Kill bullet points** — max 3 per slide, or use images instead\n- **Big text** — what looks good on laptop doesn't look good projected\n\n#### Step 4: Content/Media (Do This BEFORE Opening/Closing)\n\nFor each slide, check:\n- [ ] Does it convey exactly ONE idea?\n- [ ] Is the text big enough to read from the back?\n- [ ] Are bullet points minimized? (max 3, highlight one at a time)\n- [ ] Colors: max 5, consistent palette\n- [ ] Code: monospace, large, syntax highlighted, show LESS not more\n- [ ] Charts: simplified, noise removed, key data highlighted\n- [ ] Architecture diagrams: progressive reveal, not everything at once\n- [ ] Numbers: big and prominent (they're proof, not the story)\n\n**Oren Efraim:** 10-30 seconds per slide. If you need more time, split the slide.\n\n#### Step 5: Opening and Closing (LAST — Michal's Rule)\n\n**Opening is the LAST thing you write.** You need to know all your slides before you know the best hook.\n\n**5 Hook Types (Oren Efraim):**\n\n| Type | How | Example |\n|------|-----|---------|\n| Question | Trigger curiosity | \"What happens when you build something for yourself and it becomes a system?\" |\n| Shared Pain | Empathy hook | \"Remember deleting the production database?\" |\n| Personal Story | Create proximity | \"Two years ago I couldn't speak in front of anyone...\" |\n| Stunning Fact | Challenge assumptions | \"We see 1,200 presentations a year. We remember 3%.\" |\n| Paint a Future | Optimism hook | \"Imagine a world where every talk you give is remembered.\" |\n\n**Closing:** The LAST point MUST callback to the opening. Full circle = closure.\n\n**Session 2 output:** A complete presentation wireframe — structure, polished slides, opening, closing. Ready to practice.\n\n---\n\n### Session 3: Practice and Polish\n\n**Goal:** Make the presentation as good as possible. Practice, get feedback, refine.\n\nThis is where you take the wireframe from Session 2 and turn it into a performance.\n\n#### Practice Runs\n\n- Practice **out loud** — don't just skim in your head (Oren Efraim)\n- **Memorize only the first 30 sec - 2 min** — the opening must be smooth and powerful\n- After opening, use slides as anchors — each slide = one message, talk naturally\n- **Record yourself** (video) — watching yourself is the fastest improvement\n- Time it: 1 minute = ~150 words\n- Have water nearby — drinking = strategic pause\n\nIf voice is available (VoiceLayer), use `voice_ask` for practice runs:\n- Speak the opening, get feedback\n- Time the full run\n- Note where energy drops\n\n#### Review Checklist\n\n- [ ] Premise is clear in the first 2 minutes\n- [ ] Hook grabs attention (not \"Hi, I'm X and today I'll talk about...\")\n- [ ] Each slide = one message\n- [ ] Energy varies: warm (story) → cool (technical) → warm (insight) → cool (data) → warm (close)\n- [ ] Closing callbacks to opening\n- [ ] Timed and within limit\n- [ ] First 30 sec - 2 min memorized cold\n\n#### Feedback to Give/Look For\n\n- Where did energy drop?\n- Which slide felt too long?\n- Was the hook compelling?\n- Did the closing feel connected to the opening?\n- Audience engagement: would you have stayed?\n\n#### Present to the Group\n\nShow your opening, get live feedback, iterate. This is the final polish before the real event.\n\n---\n\n## Delivery Rules (Quick Reference)\n\n### Voice & Pace\n\n- Speak clearly, vary pace — slow for important, faster for setup\n- Use **methodical pauses** — silence after key points is powerful\n- Water = strategic pause when rushing or confused\n\n### Body\n\n- Stand, don't sit. Use the stage. Hands visible.\n- Face the audience, not the screen\n- Eye contact with individuals (3-5 sec each), including back rows\n\n### Nerves\n\n- Reframe: excitement, not fear (same physical symptoms)\n- Breathing: 5 sec in, 5 sec out (Huberman protocol)\n- First 30 seconds are the hardest — it gets easier\n- Know your first sentences cold\n\n### DON'T\n\n- Don't memorize word-for-word — sounds robotic\n- Don't apologize (\"This is my first time\")\n- Don't read slides with your back to the audience\n- Don't switch languages mid-sentence (unless technical term)\n\n### Environment\n\n- Arrive early, check projector/adapter\n- Close all notifications (DND mode)\n- Know your mic type (Madonna = belt pack)\n- Conferences are always cold — wear sleeves\n\n### Audience Engagement\n\n- Raise hands / small jokes work in most cases\n- Have a comeback if audience doesn't participate\n- **The Airplane! trick:** Plant a mystery number/fact at the start — someone will ask about it at the end (solves \"no questions\" problem)\n\n### Q&A (Uri Alon)\n\n- Listen to the full question\n- Repeat it for the audience\n- \"I don't know\" is valid — follow with \"but here's what I think...\"\n- Long/confused questions: \"Let me make sure I understand — are you asking...?\"\n\n---\n\n## Voice Integration\n\nWhen VoiceLayer is available, use it for:\n- **Practice runs:** `voice_ask` — speak the opening, get timed feedback\n- **Debrief after presenting:** `voice_ask` — \"How did it go? What would you change?\"\n- **Quick notes during review:** `voice_speak` — capture insights silently (use `insight:` prefix)\n- **Reading back the premise:** `voice_speak` — hear it spoken, check if it sounds natural\n\n---\n\n## Sources\n\n- **Oren Efraim** — \"The Art of Building and Delivering Great Presentations\" (TechGym YouTube)\n- **Michal** — Speakers Workshop at Melio (TechGym, Feb 2026)\n- **Uri Alon** — \"How to Give a Good Talk\" (Weizmann Institute, PubMed)\n- **Oren Eini** — Technical Presentation Delivery Notes (RavenDB/Ayende)\n- **Ben Orenstein** — Speaking for Hackers\n- **Method Queen** — How to Build a Good Lecture (Hebrew)\n- **Harvard** — 10 Tips for Public Speaking\n",
+      "evalCount": 3,
+      "assertionCount": 7,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 3,
+          "assertions": [
+            "starts-with-premise",
+            "follows-workshop-phases",
+            "includes-opening-and-closing"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 2,
+          "assertions": [
+            "resists-skipping-premise",
+            "asks-about-audience"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 2,
+          "assertions": [
+            "includes-practice-step",
+            "offers-voice-practice"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-01"
+    },
+    "project-context": {
+      "name": "project-context",
+      "command": "/project-context",
+      "description": "Use at session start or when unsure what tools are available. Auto-detects project stack and shows relevant skills. Covers project detection, what skills, available tools. NOT for: mid-session skill lookup (use /skills), invoking specific skills (call them directly).",
+      "category": "Other",
+      "content": "\n# Project Context (Auto-Detected)\n\nThis skill auto-detects your project's tools and tells you which skills are available.\n\n## Detected Environment\n\n!`~/.claude/commands/golem-powers/project-context/scripts/detect.sh 2>/dev/null || echo \"Detection script not found\"`\n\n## Universal Skills (Always Available)\n\n| Skill | When to Use |\n|-------|-------------|\n| `/ralph-commit` | For \"Commit:\" criteria - atomic commit + criterion check |\n| `/coderabbit` | Code review before commits (iterate until clean) |\n| `/context7` | Look up library docs when unsure about APIs |\n| `/github` | Git operations, PRs, issues |\n| `/create-pr` | Push branch and create PR |\n| `/catchup` | Context recovery after long breaks |\n\n## How to Use\n\n1. **Check detected tools above** - See what's available in this project\n2. **Use universal skills** - Always available regardless of project\n3. **Use project-specific skills** - Only if detected above\n\nInvoke any skill with `/skill-name` or read its SKILL.md for detailed workflows.\n",
+      "evalCount": 0,
+      "assertionCount": 0,
+      "hasFixtures": false,
+      "evals": [],
+      "workflows": [],
+      "lastModified": "2026-03-02"
+    },
+    "railway": {
+      "name": "railway",
+      "command": "/railway",
+      "description": "Deploy and manage the golems cloud-worker on Railway. Use when deploying backend changes, checking logs, managing env vars, or restarting services. Wraps `railway` CLI. Covers railway, deploy, cloud-worker, redeploy, logs, variables. NOT for: Vercel deployments, frontend, Supabase.",
+      "category": "Operations",
+      "content": "\n# Railway Operations\n\n> Manages the golems cloud-worker service on Railway. The cloud-worker runs email poller, job scraper, briefing, and soltome learner.\n\n## Working Directory\n\nRailway CLI commands can be run directly — no `cd` required. The `railway` CLI uses the linked project config, not the working directory.\n\nIf you do get a \"Could not find root directory\" error, it means `railway link` has not been run yet for this project.\n\n---\n\n## Project Info\n\n| Key | Value |\n|-----|-------|\n| Project | `helpful-empathy` |\n| Service | `golems` |\n| Environment | `production` |\n| Entry point | `bun run src/cloud-worker.ts` |\n| Health check | `/health` |\n\n---\n\n## Quick Actions\n\n| What you want to do | Workflow |\n|---------------------|----------|\n| Deploy latest code | [workflows/deploy.md](workflows/deploy.md) |\n| Check logs | [workflows/logs.md](workflows/logs.md) |\n| Manage env vars | [workflows/variables.md](workflows/variables.md) |\n| Restart without rebuilding | [workflows/restart.md](workflows/restart.md) |\n| Check status | [workflows/status.md](workflows/status.md) |\n\n---\n\n## When to Deploy\n\nDeploy to Railway after merging PRs that change:\n- `packages/services/src/cloud-worker.ts` (schedules, worker config)\n- `packages/shared/src/email/` (email processing)\n- `packages/jobs/src/` (job scraping)\n- `packages/shared/src/lib/cloud-llm.ts` (Haiku backend)\n- `railway.json`\n\nDo NOT forget to deploy after backend PRs merge. Use the CLI — no \"manual redeploy\" needed.\n",
+      "evalCount": 0,
+      "assertionCount": 0,
+      "hasFixtures": false,
+      "evals": [],
+      "workflows": [
+        "deploy",
+        "logs",
+        "restart",
+        "status",
+        "variables"
+      ],
+      "lastModified": "2026-03-01"
+    },
+    "ralph-commit": {
+      "name": "ralph-commit",
+      "command": "/ralph-commit",
+      "description": "Use when reaching a \"Commit:\" criterion in Ralph stories. Atomically commits and marks criterion checked. Covers ralph commit, atomic commit, commit criterion. NOT for: regular git commits (use git directly), commits outside Ralph workflow.",
+      "category": "Other",
+      "content": "\n# Skill: Ralph Commit (Atomic Commit + Check)\n\n> Use when hitting a \"Commit: ...\" acceptance criterion in a Ralph story. Commits atomically with criterion marking - if commit fails (tests fail), criterion stays unchecked.\n\n## Usage\n\n```bash\n/ralph-commit --story=US-106 --message=\"feat: US-106 description\"\n```\n\n## What It Does\n\n1. **Stages files** (specified or auto-detected)\n2. **Commits** (pre-commit hook runs all tests)\n3. **If commit succeeds** → marks the commit criterion as checked in story JSON\n4. **If commit fails** → neither happens, reports failure\n\n## Flags\n\n| Flag | Description |\n|------|-------------|\n| `--story=ID` | Story ID (e.g., US-106, BUG-028) - required |\n| `--message=MSG` | Commit message - required |\n| `--files=PATHS` | Files to stage (default: prd-json/ + modified files) |\n| `--dry-run` | Show what would happen without doing it |\n\n## Example\n\n```bash\n# After completing US-106 work:\n/ralph-commit --story=US-106 --message=\"feat: US-106 UI foundation\"\n\n# Success output:\n# ✓ Committed (all tests passed)\n# ✓ Marked commit criterion as checked in US-106.json\n\n# Failure output:\n# ✗ Commit failed (tests failed in pre-commit hook)\n# → Fix tests, then retry\n# → Commit criterion NOT checked\n```\n\n## Why Use This\n\n- **Atomic**: Either both happen (commit + check) or neither\n- **No double-testing**: Uses pre-commit hook, doesn't run tests twice\n- **Clean failure**: If tests fail, criterion stays unchecked for retry\n",
+      "evalCount": 0,
+      "assertionCount": 0,
+      "hasFixtures": false,
+      "evals": [],
+      "workflows": [],
+      "lastModified": "2026-03-01"
+    },
+    "research": {
+      "name": "research",
+      "command": "/research",
+      "description": "Deep web research orchestrator. Routes research tasks to the best backend — internal subagents, CLI agents (Gemini/Cursor), or the researcher subagent. Use when asked to research, investigate, compare, find alternatives, or deep-dive into any topic. Covers web research, company research, code pattern research, and pre-implementation research.",
+      "category": "Research & Context",
+      "content": "\n# Research Skill\n\nMulti-backend research orchestrator. Routes to the cheapest effective tool for each task.\n\n## Modes\n\n| Command | Backend | Cost | Sources | Time | Best For |\n|---------|---------|------|---------|------|----------|\n| `/research \"topic\"` | Researcher subagent | $0 (subscription) | 15-25 | 3-5 min | General web research |\n| `/research --quick \"topic\"` | WebSearch + WebFetch (inline) | $0 | 5-8 | 1-2 min | Quick lookups |\n| `/research --deep \"topic\"` | Researcher subagent (max depth) | $0 | 40-80 | 10-20 min | Comprehensive research |\n| `/research --company \"name\"` | Exa company_research | Free credits | 10-15 | 2-3 min | Company/product intel |\n| `/research --code \"pattern\"` | CLI agents swarm (Gemini) | $0 | N/A | 3-5 min | Code patterns, library comparison |\n| `/research --paper \"topic\"` | research-paper-analyst agent | $0 | arXiv | 5-10 min | Academic papers |\n| `/research --audit \"repo/code\"` | CLI agents (Gemini + Cursor) | $0-20/mo | N/A | 5-10 min | Code audit, pre-PR review |\n| `/research --external \"topic\"` | CLI agents (Gemini) | $0 | Web | 3-5 min | Offload from Opus context |\n\n## Workflow: Default Research\n\n1. **Check BrainLayer first** — `brain_search(query)` may already have what you need\n2. **Launch researcher subagent** in background:\n   ```\n   Task(subagent_type: \"researcher\", prompt: \"Research: {topic}\", run_in_background: true)\n   ```\n3. **Continue working** while research runs\n4. **Read results** when notified — researcher saves to `docs.local/research/[date]-[slug].md`\n5. **Digest to BrainLayer** if worth keeping: `brain_digest(content)` then delete the file\n\n## Workflow: Quick Research (inline)\n\nNo subagent — run directly in current context:\n\n1. Run 3-5 `WebSearch` queries in parallel\n2. `WebFetch` top 3-5 results\n3. Synthesize inline\n4. Continue working\n\nUse when you need a quick answer, not a report.\n\n## Workflow: Company Research\n\nFor job leads, freelance prospects, meeting prep:\n\n1. `company_research_exa(company_name)` — get company overview\n2. `web_search_exa(\"company_name funding team size tech stack\")` — deeper intel\n3. `brain_search(\"company_name\")` — check if we've seen them before\n4. Output structured brief:\n   - What they do (1 sentence)\n   - Tech stack / relevant tech\n   - Recent news / funding\n   - Connection to our skills\n   - Red flags\n\n## Workflow: Code Research\n\nFor library comparison, pattern discovery, architecture decisions:\n\n1. **BrainLayer check**: `brain_search(\"topic\")` — past decisions?\n2. **Exa code context**: `get_code_context_exa(\"pattern/library\")` — real code examples\n3. **CLI agent (Gemini)**: `run.sh gemini \"Compare X vs Y for [use case]\"` — free, detailed analysis\n4. **Optional: Cursor audit**: `run.sh cursor \"Review this code pattern: ...\"` — GPT-5.2 perspective\n\n## Workflow: External Research (offload from Opus)\n\nWhen the main Claude Code session is expensive Opus and you want cheap research:\n\n```bash\n# Gemini does the research, saves to file (FREE)\n~/.claude/commands/cli-agents/scripts/run.sh gemini \"Research: {full prompt}\" docs.local/research/$(date +%Y%m%d)-research.md\n```\n\nThen read the output file. Gemini is free (1K/day) and good for general research.\n\n## Workflow: Deep Research (Claude Web-quality)\n\nFor comprehensive research matching Claude Web's 463-source depth:\n\n1. **Launch researcher subagent** with explicit depth:\n   ```\n   Task(subagent_type: \"researcher\", prompt: \"COMPREHENSIVE deep research on: {topic}. Target 40+ sources. Run 25+ search queries. Cross-reference all claims.\", run_in_background: true)\n   ```\n2. **Supplement with CLI agents** for extra perspectives:\n   ```bash\n   run.sh gemini \"Deep research on {topic} — focus on {angle A}\" /tmp/research-gemini.md\n   ```\n3. **Merge results** — researcher report + Gemini output = comprehensive coverage\n4. **Store in BrainLayer** — `brain_store` the synthesis for future retrieval\n\n## Workflow: Pre-PR Audit\n\nExtra eyes before PR loop:\n\n1. **Gemini review**: `run.sh gemini \"Review this diff for bugs, security issues, and missed edge cases: $(git diff main..HEAD)\"` — free\n2. **Cursor review**: `run.sh cursor \"Audit this code change: ...\"` — GPT-5.2 perspective\n3. **Both in parallel** — compare their findings\n4. Fix issues before pushing\n\n## Integration Points\n\n| System | How Research Connects |\n|--------|----------------------|\n| `/large-plan` | Research phases auto-route here. Plan scaffold includes research tasks per phase |\n| `/jobs` pipeline | Company research before applying. `--company` mode |\n| Gems pipeline | Research-backed gem discovery via `--paper` mode |\n| Meeting notes | Pre-meeting research on participants/companies |\n| PR loops | Pre-PR code audit via `--audit` mode |\n| BrainLayer | All research results stored for future retrieval |\n\n## Cost Summary\n\n| Backend | Cost | Limit |\n|---------|------|-------|\n| WebSearch/WebFetch | $0 (included in subscription) | Unlimited |\n| Exa | Free credits (2K one-time) | Then $5/1K |\n| Gemini CLI | $0 | 1K requests/day |\n| Researcher subagent | $0 (subscription) | Context window |\n| Cursor CLI | $20/mo (Cursor Pro) | Unlimited |\n| research-paper-analyst | $0 (subscription) | Context window |\n\n**Default stack is 100% free**: WebSearch + Exa free credits + Gemini CLI.\n\n## Output Location\n\n| Type | Location |\n|------|----------|\n| Quick research | Inline (no file) |\n| Standard research | `/tmp/research-[slug].md` (ephemeral) |\n| Worth keeping | `docs.local/research/[date]-[slug].md` |\n| BrainLayer | Auto-stored via `brain_store` |\n\n## Future: n8n Deep Research Pipeline\n\nWhen n8n orchestrator is set up (`packages/orchestrator`), add:\n- Scheduled research (e.g., weekly job market scan)\n- 400+ source deep research via recursive search loops\n- Automated BrainLayer ingestion of research results\n- Research templates (company intel, tech comparison, market scan)\n\nTemplate exists: [n8n deep research workflow](https://n8n.io/workflows/2878)\n",
+      "evalCount": 3,
+      "assertionCount": 10,
+      "hasFixtures": true,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 4,
+          "assertions": [
+            "checks-brainlayer-first",
+            "uses-researcher-subagent-for-default-mode",
+            "runs-research-in-background",
+            "plans-to-store-keepable-results"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "uses-inline-web-research-for-quick-mode",
+            "parallelizes-search-queries",
+            "returns-inline-without-report-file"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "routes-audit-mode-to-cli-agents",
+            "uses-multiple-audit-backends-in-parallel",
+            "compares-findings-before-conclusion"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-06"
+    },
+    "skills": {
+      "name": "skills",
+      "command": "/skills",
+      "description": "Use when wanting to see what skills are available. Lists installed skills with descriptions. Covers list skills, search skills, discover skills, what skills. NOT for: using a specific skill (invoke that skill directly).",
+      "category": "Quality",
+      "content": "\n# Skills Discovery\n\n> List and search your installed Claude Code skills.\n\n## Usage\n\nWhen invoked via `/skills`, scan and display all available skills. If the user provides arguments like `--search <keyword>`, filter accordingly.\n\n## Instructions\n\n### Step 1: Scan Skills Directory\n\nRun this to discover all skills:\n\n```bash\n#!/bin/bash\nSKILLS_DIR=\"$HOME/.claude/commands\"\n\necho \"# Installed Skills\"\necho \"\"\n\n# Arrays to hold skills by category\ndeclare -a domain_skills\ndeclare -a infra_skills\ndeclare -a custom_skills\n\n# Function to extract description from a file\nextract_desc() {\n    local file=\"$1\"\n    # First try YAML frontmatter description\n    if head -1 \"$file\" | grep -q '^---$'; then\n        desc=$(awk '/^---$/{p++} p==1 && /^description:/{gsub(/^description: */, \"\"); print; exit}' \"$file\")\n        if [[ -n \"$desc\" ]]; then\n            echo \"$desc\"\n            return\n        fi\n    fi\n    # Fall back to first # header blockquote\n    desc=$(awk '/^#/{found=1} found && /^>/{gsub(/^> */, \"\"); print; exit}' \"$file\")\n    if [[ -n \"$desc\" ]]; then\n        echo \"$desc\"\n        return\n    fi\n    # Final fallback: first non-empty line after header\n    awk '/^#/{found=1; next} found && NF{print; exit}' \"$file\"\n}\n\n# Function to count workflows in a directory\ncount_workflows() {\n    local dir=\"$1\"\n    if [[ -d \"$dir/workflows\" ]]; then\n        find \"$dir/workflows\" -name \"*.md\" 2>/dev/null | wc -l | tr -d ' '\n    else\n        echo \"0\"\n    fi\n}\n\n# Function to determine source of a skill\nget_source() {\n    local path=\"$1\"\n    local resolved=$(readlink -f \"$path\" 2>/dev/null || echo \"$path\")\n\n    if [[ \"$resolved\" == *\"/golem-powers/\"* ]] || [[ \"$resolved\" == *\"/golems/skills/\"* ]]; then\n        echo \"golem-powers\"\n    elif [[ \"$resolved\" == *\"/superpowers/\"* ]]; then\n        echo \"superpowers\"\n    elif [[ \"$resolved\" == *\"/golems/\"* ]] || [[ \"$resolved\" == *\"/.config/golems/\"* ]]; then\n        echo \"golem-powers\"\n    else\n        echo \"custom\"\n    fi\n}\n\n# Function to categorize skill\ncategorize_skill() {\n    local name=\"$1\"\n    local desc=\"$2\"\n\n    # Infrastructure skills\n    if echo \"$name $desc\" | grep -qiE 'git|github|commit|push|pr|1password|secret|vault|credential'; then\n        echo \"infra\"\n    # Domain skills (browser, PRD, etc)\n    elif echo \"$name $desc\" | grep -qiE 'brave|browser|prd|product|archive|critique'; then\n        echo \"domain\"\n    else\n        echo \"custom\"\n    fi\n}\n\n# Scan for skills (handles namespaced skills like golem-powers/)\nscan_skill_dir() {\n    local dir=\"$1\"\n    local namespace=\"$2\"\n\n    for item in \"$dir\"/*; do\n        [[ ! -e \"$item\" ]] && continue\n        local name=$(basename \"$item\" .md)\n\n        # Skip meta items\n        [[ \"$name\" == \"skills\" ]] && continue\n\n        if [[ -d \"$item\" ]]; then\n            # Check if this is a skill directory (has SKILL.md)\n            if [[ -f \"$item/SKILL.md\" ]]; then\n                local full_name=\"${namespace}${name}\"\n                local desc=$(extract_desc \"$item/SKILL.md\")\n                local workflows=$(count_workflows \"$item\")\n                local source=$(get_source \"$item\")\n                local category=$(categorize_skill \"$name\" \"$desc\")\n                local entry=\"$full_name|$desc|$source|$workflows\"\n\n                case $category in\n                    infra) infra_skills+=(\"$entry\") ;;\n                    domain) domain_skills+=(\"$entry\") ;;\n                    *) custom_skills+=(\"$entry\") ;;\n                esac\n            else\n                # This is a namespace directory (like golem-powers/), recurse\n                scan_skill_dir \"$item\" \"${name}:\"\n            fi\n        elif [[ -f \"$item\" && \"$item\" == *.md ]]; then\n            # Single-file skill\n            local full_name=\"${namespace}${name}\"\n            local desc=$(extract_desc \"$item\")\n            local source=$(get_source \"$item\")\n            local category=$(categorize_skill \"$name\" \"$desc\")\n            local entry=\"$full_name|$desc|$source|0\"\n\n            case $category in\n                infra) infra_skills+=(\"$entry\") ;;\n                domain) domain_skills+=(\"$entry\") ;;\n                *) custom_skills+=(\"$entry\") ;;\n            esac\n        fi\n    done\n}\n\n# Start scanning from the root commands directory\nscan_skill_dir \"$SKILLS_DIR\" \"\"\n\n# Print function\nprint_skills() {\n    local title=\"$1\"\n    shift\n    local skills=(\"$@\")\n\n    if [[ ${#skills[@]} -gt 0 ]]; then\n        echo \"## $title\"\n        echo \"\"\n        echo \"| Skill | Description | Source | Workflows |\"\n        echo \"|-------|-------------|--------|-----------|\"\n        for skill in \"${skills[@]}\"; do\n            IFS='|' read -r name desc source workflows <<< \"$skill\"\n            if [[ \"$workflows\" -gt 0 ]]; then\n                echo \"| **$name** | $desc | $source | $workflows |\"\n            else\n                echo \"| **$name** | $desc | $source | - |\"\n            fi\n        done\n        echo \"\"\n    fi\n}\n\n# Output grouped by category\nprint_skills \"Infrastructure\" \"${infra_skills[@]}\"\nprint_skills \"Domain\" \"${domain_skills[@]}\"\nprint_skills \"Custom\" \"${custom_skills[@]}\"\n\necho \"---\"\necho \"*Use \\`/skills --search <keyword>\\` to filter skills*\"\n```\n\n### Step 2: Handle Search Filter\n\nIf the user invoked `/skills --search <keyword>`, modify the output to filter:\n\n```bash\nSEARCH=\"$1\"  # e.g., \"git\" or \"browser\"\n\n# In the scan loop, add filtering:\nif [[ -n \"$SEARCH\" ]]; then\n    if ! echo \"$name $desc\" | grep -qi \"$SEARCH\"; then\n        continue  # Skip non-matching skills\n    fi\nfi\n```\n\n### Step 3: Present Results\n\nAfter running the discovery script, present the results in a clean markdown table grouped by category:\n\n1. **Infrastructure** - git, github, secrets, credentials\n2. **Domain** - browser, PRD, specific tools\n3. **Custom** - user-created skills\n\nFor each skill, show:\n- **Name**: The skill command (e.g., `/github`)\n- **Description**: From frontmatter or first paragraph\n- **Source**: Where it comes from (golem-powers, superpowers, custom)\n- **Workflows**: Count of sub-workflows for progressive disclosure skills\n\n## Example Output\n\n```\n# Installed Skills\n\n## Infrastructure\n\n| Skill | Description | Source | Workflows |\n|-------|-------------|--------|-----------|\n| **github** | Git and GitHub CLI operations | golem-powers | 4 |\n| **1password** | Secret management with 1Password | golem-powers | 5 |\n\n## Domain\n\n| Skill | Description | Source | Workflows |\n|-------|-------------|--------|-----------|\n| **brave** | Browser automation via brave-manager | golem-powers | - |\n| **prd** | Generate Product Requirements Documents | golem-powers | - |\n| **archive** | Archive completed PRD stories | golem-powers | - |\n\n---\n*Use `/skills --search <keyword>` to filter skills*\n```\n\n## Quick Reference\n\n- `/skills` - List all installed skills\n- `/skills --search git` - Find skills related to git\n- `/skills --search secret` - Find skills for secrets management\n",
+      "evalCount": 3,
+      "assertionCount": 12,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 6,
+          "assertions": [
+            "scans-commands-directory",
+            "groups-by-category",
+            "shows-description-not-content",
+            "includes-source-column",
+            "includes-workflow-count",
+            "includes-superpowers"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "filters-by-keyword",
+            "maintains-table-format",
+            "case-insensitive-search"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "does-not-dump-full-contents",
+            "suggests-direct-invocation",
+            "still-shows-table"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-06"
+    },
+    "test-plan": {
+      "name": "test-plan",
+      "command": "/test-plan",
+      "description": "Use when preparing a PR for QA review. Generates manual testing checklist from git diff. Covers test plan, QA checklist, testing before merge. NOT for: automated tests (write those separately), code reviews (use coderabbit).",
+      "category": "Development",
+      "content": "\n# Generate Test Plan\n\nAnalyze changes in the current Git branch and generate a manual testing checklist organized by page/feature.\n\n## Quick Start\n\nThe skill auto-runs on load. Override the base branch:\n\n```bash\n./scripts/generate.sh --base main\n./scripts/generate.sh --base dev\n./scripts/generate.sh --base origin/staging\n```\n\n## What It Does\n\n1. Gets the diff against the base branch (default: main)\n2. Categorizes changed files by type (UI, API, DB, Config, etc.)\n3. Generates a Markdown checklist grouped by feature/component\n4. Includes regression test suggestions for related areas\n\n## Output Format\n\n```markdown\n## Test Plan\n\n### [Feature/Component Name]\n- [ ] Test: Description of what to verify\n- [ ] Test: Another thing to check\n\n### API Changes\n- [ ] Test: Verify endpoint returns expected shape\n- [ ] Test: Error responses have correct status codes\n\n### Database/Schema\n- [ ] Test: Verify migrations run cleanly\n- [ ] Test: Data integrity after changes\n\n### Configuration\n- [ ] Test: Verify env vars are documented\n- [ ] Test: Config changes don't break existing deploys\n\n### General\n- [ ] No console errors during testing\n- [ ] No TypeScript/build errors\n- [ ] Mobile responsive (if UI changes)\n```\n\n## Guidelines\n\n- **Be specific**: \"Verify user can submit form\" not \"Test form\"\n- **Include edge cases**: Empty states, error states, loading states\n- **Consider permissions**: Test as different user roles if auth-related\n- **Note regressions**: If touching shared code, note areas that could regress\n- **Prioritize**: Put most critical tests first within each section\n\n## Usage\n\nRun this skill before creating a PR to generate the test plan section for your PR description.\n",
+      "evalCount": 3,
+      "assertionCount": 13,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 6,
+          "assertions": [
+            "generates-from-git-diff",
+            "grouped-by-feature-component",
+            "checkable-markdown-format",
+            "includes-edge-cases",
+            "includes-regression-suggestions",
+            "specific-not-generic"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "runs-diff-despite-user-description",
+            "executes-generate-script",
+            "may-find-additional-changes"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 4,
+          "assertions": [
+            "respects-base-branch-override",
+            "categorizes-all-file-types",
+            "prioritizes-critical-tests",
+            "includes-setup-steps"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-01"
+    },
+    "video-showcase": {
+      "name": "video-showcase",
+      "command": "/video-showcase",
+      "description": "Create product/project showcase videos using Remotion (React). Takes project description + screenshots → generates compositions → renders MP4. Use when asked to make demo videos, product showcases, or animated project walkthroughs.",
+      "category": "Content & Communication",
+      "content": "\n# Video Showcase — Remotion Video Generator\n\n> Create polished 60-90 second product showcase videos programmatically using React + Remotion.\n\n## Prerequisites\n\n- **Remotion project** initialized in `~/Gits/contentGolem/remotion/`\n- **ffmpeg** installed (`brew install ffmpeg`)\n- **Chrome/Chromium** for headless rendering (Remotion bundles this)\n\n## Quick Reference\n\n| Action | Command |\n|--------|---------|\n| Preview | `cd ~/Gits/contentGolem/remotion && npx remotion preview` |\n| Render | `npx remotion render <CompositionId> out/video.mp4 --props='{\"title\":\"My Project\"}'` |\n| Batch render | Use `renderMedia()` API in a script (see below) |\n\n## Workflow\n\n### 1. Gather Inputs\n\nCollect from user:\n- **Project name** and tagline\n- **Screenshots** (2-5 key screens, placed in `remotion/public/`)\n- **Key features** (3-5 bullet points)\n- **Tech stack** (for badges/icons)\n- **Color palette** (or extract from screenshots)\n- **Duration** preference (30s / 60s / 90s)\n\n### 2. Choose Template\n\n| Template | Best For | Duration |\n|----------|----------|----------|\n| `ProductHero` | SaaS/web app with screenshots | 60s |\n| `CodeWalkthrough` | Developer tools, CLI, libraries | 90s |\n| `BeforeAfter` | Redesigns, improvements | 45s |\n| `MetricShowcase` | Growth, performance, stats | 30s |\n| `ArchitectureDiagram` | System design, infrastructure | 60s |\n\n### 3. Generate Composition\n\nCreate a new TSX composition file in `remotion/src/compositions/`:\n\n```tsx\nimport { useCurrentFrame, useVideoConfig, interpolate, spring, Sequence, AbsoluteFill, Img } from \"remotion\";\nimport { staticFile } from \"remotion\";\n\ntype Props = {\n  title: string;\n  tagline: string;\n  features: string[];\n  screenshots: string[];  // filenames in public/\n  colors: { primary: string; bg: string; text: string };\n};\n\nexport const ProductHero: React.FC<Props> = ({ title, tagline, features, screenshots, colors }) => {\n  const frame = useCurrentFrame();\n  const { fps } = useVideoConfig();\n\n  // Intro: title + tagline fade in (0-2s)\n  // Screenshots: pan/zoom through each (2-8s per screenshot)\n  // Features: slide in one by one (2s each)\n  // Outro: call to action (last 3s)\n\n  return (\n    <AbsoluteFill style={{ backgroundColor: colors.bg }}>\n      {/* Build composition here */}\n    </AbsoluteFill>\n  );\n};\n```\n\n### 4. Render\n\n```bash\n# Preview in browser\nnpx remotion preview\n\n# Render to MP4\nnpx remotion render ProductHero out/showcase.mp4 \\\n  --props='{\"title\":\"My App\",\"tagline\":\"Ship faster\",\"features\":[\"Fast\",\"Reliable\",\"Beautiful\"],\"screenshots\":[\"screen1.png\",\"screen2.png\"],\"colors\":{\"primary\":\"#3B82F6\",\"bg\":\"#0F172A\",\"text\":\"#F8FAFC\"}}'\n\n# Render for specific platform\nnpx remotion render ProductHero out/linkedin.mp4 --width=1920 --height=1080  # LinkedIn\nnpx remotion render ProductHero out/twitter.mp4 --width=1280 --height=720   # Twitter/X\nnpx remotion render ProductHero out/short.mp4 --width=1080 --height=1920    # Reels/Shorts\n```\n\n## Critical Remotion Rules\n\n1. **NO CSS/Tailwind animations** — all animation MUST be frame-based (`interpolate`, `spring`, `useCurrentFrame`)\n2. **No `setTimeout`/`setInterval`** — Remotion is deterministic, frame-by-frame\n3. **Use `<Sequence from={N}>` for timing** — not conditional rendering based on time\n4. **Use `staticFile()` for local assets** — files go in `public/` directory\n5. **Use `spring()` for natural motion** — not linear `interpolate` for UI elements\n6. **`extrapolateRight: 'clamp'`** — always clamp to prevent values going past target\n7. **Props are JSON-serializable** — no functions, no React elements in props\n\n## Animation Patterns\n\n### Fade In\n```tsx\nconst opacity = interpolate(frame, [0, 2 * fps], [0, 1], { extrapolateRight: 'clamp' });\n```\n\n### Spring Slide\n```tsx\nconst translateX = spring({ frame, fps, from: -100, to: 0, config: { damping: 12 } });\n```\n\n### Staggered List\n```tsx\n{features.map((f, i) => (\n  <Sequence from={startFrame + i * staggerDelay} key={i}>\n    <AnimatedFeature text={f} />\n  </Sequence>\n))}\n```\n\n### Screenshot Pan/Zoom\n```tsx\nconst scale = interpolate(frame, [0, duration], [1, 1.15], { extrapolateRight: 'clamp' });\nconst translateY = interpolate(frame, [0, duration], [0, -50], { extrapolateRight: 'clamp' });\n```\n\n## Data-Driven Batch Rendering\n\n```typescript\nimport { renderMedia, selectComposition } from '@remotion/renderer';\n\nconst projects = [\n  { title: \"Project A\", screenshots: [\"a1.png\", \"a2.png\"], ... },\n  { title: \"Project B\", screenshots: [\"b1.png\", \"b2.png\"], ... },\n];\n\nfor (const project of projects) {\n  const composition = await selectComposition({\n    serveUrl: bundleLocation,\n    id: 'ProductHero',\n    inputProps: project,\n  });\n  await renderMedia({\n    composition,\n    serveUrl: bundleLocation,\n    codec: 'h264',\n    outputLocation: `out/${project.title}.mp4`,\n    inputProps: project,\n  });\n}\n```\n\n## Export Settings by Platform\n\n| Platform | Resolution | Codec | FPS | Notes |\n|----------|-----------|-------|-----|-------|\n| LinkedIn | 1920x1080 | h264 | 30 | Max 10 min, <200MB |\n| Twitter/X | 1280x720 | h264 | 30 | Max 2:20, <512MB |\n| YouTube | 1920x1080 | h264 | 30 | 16:9 preferred |\n| Reels/Shorts | 1080x1920 | h264 | 30 | 9:16 vertical |\n| GitHub README | 800x600 | gif | 15 | Keep <10MB |\n\n## See Also\n\n- [Remotion docs](https://www.remotion.dev/docs/)\n- `/content` skill — for text content pipeline\n- `/linkedin-post` skill — for LinkedIn-specific posting\n",
+      "evalCount": 3,
+      "assertionCount": 12,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 6,
+          "assertions": [
+            "generates-tsx-composition",
+            "uses-remotion-frame-api",
+            "uses-sequence-for-timing",
+            "uses-static-file-for-assets",
+            "renders-to-mp4",
+            "clamps-extrapolation"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "rejects-css-animations",
+            "uses-frame-based-animation-anyway",
+            "no-settimeout-setinterval"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "uses-batch-render-api",
+            "separate-output-per-project",
+            "json-serializable-props"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-06"
+    },
+    "voice-sessions": {
+      "name": "voice-sessions",
+      "command": "/voice-sessions",
+      "description": "Use when debriefing meetings, practicing presentations, QA testing with voice, or capturing insights to Obsidian. Covers voice drilling, coaching, capture. NOT for: simple TTS announcements (use voice_speak directly).",
+      "category": "Content & Communication",
+      "content": "\n# Voice Sessions\n\n> Structured voice-powered sessions using VoiceLayer MCP.\n\n## Workflows\n\n| What you want to do | Workflow |\n|---------------------|---------|\n| Debrief a conversation | [workflows/debrief.md](workflows/debrief.md) |\n| Practice a presentation/pitch | [workflows/practice.md](workflows/practice.md) |\n| QA test a site with voice | [workflows/qa.md](workflows/qa.md) |\n| Quick text-only capture | [workflows/quick.md](workflows/quick.md) |\n| Review past sessions | [workflows/review.md](workflows/review.md) |\n\n## How It Works\n\nTypical flow: Context → Walk-through → Drill → Capture → Output (Obsidian note).\n\nVoice tools: `voice_speak` (non-blocking TTS) + `voice_ask` (blocking Q&A). Mode is auto-detected from message content.\n\n## Requirements\n\n- VoiceLayer MCP connected\n- Obsidian vault configured\n- Text fallback available if voice isn't connected\n",
+      "evalCount": 3,
+      "assertionCount": 8,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 3,
+          "assertions": [
+            "uses-voicelayer-tools",
+            "asks-probing-questions",
+            "stores-in-obsidian"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 2,
+          "assertions": [
+            "graceful-voice-fallback",
+            "maintains-practice-structure"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "uses-qa-workflow",
+            "references-qa-schemas",
+            "records-test-results"
+          ]
+        }
+      ],
+      "workflows": [
+        "code",
+        "debrief",
+        "practice",
+        "qa",
+        "quick",
+        "review"
+      ],
+      "lastModified": "2026-03-01"
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "command": "/worktrees",
+      "description": "Use when starting isolated feature work. Creates git worktrees to prevent branch cross-contamination. Covers worktree, isolated development, parallel features, branch isolation. NOT for: simple branch switching (use git checkout), Linear-only operations (use linear).",
+      "category": "Development",
+      "content": "\n# Git Worktrees\n\n> Create isolated working directories for each task. Worktrees share git history but have separate working files, preventing cross-contamination between branches.\n\n## Quick Actions\n\n| What you want to do | Workflow |\n|---------------------|----------|\n| Create new worktree from branch name | [workflows/create.md](workflows/create.md) |\n| Create worktree from Linear issue | [workflows/from-linear.md](workflows/from-linear.md) |\n| List active worktrees | [workflows/list.md](workflows/list.md) |\n| Switch to a worktree | [workflows/switch.md](workflows/switch.md) |\n| Clean up completed worktrees | [workflows/cleanup.md](workflows/cleanup.md) |\n\n---\n\n## Default Paths\n\nWorktrees are created at: `~/worktrees/<repo>/<branch>`\n\nExample:\n- Main repo: `/Users/me/projects/my-app`\n- Worktree: `~/worktrees/my-app/feature-login`\n\n---\n\n## Environment Setup (Automatic)\n\nWorktrees automatically handle:\n- **Env files**: Uses 1Password `op inject` if `.env.template` exists, else copies `.env*.local` from source\n- **Dependencies**: Auto-detects package manager (bun/pnpm/yarn/npm) and installs\n\n| Condition | Action |\n|-----------|--------|\n| `.env.template` + `op` available | `op inject -i .env.template -o .env.local` |\n| `op inject` fails | Fallback: copy from source repo |\n| No `.env.template` | Copy all `.env*.local` from source |\n\n---\n\n## Quick Commands\n\n```bash\n# List all worktrees\ngit worktree list\n\n# Create worktree with new branch\ngit worktree add ~/worktrees/$(basename \"$PWD\")/feature-name -b feature-name\n\n# Remove worktree\ngit worktree remove ~/worktrees/$(basename \"$PWD\")/feature-name\n\n# Prune stale references\ngit worktree prune\n```\n\n---\n\n## Troubleshooting\n\n**\"fatal: 'path' already exists\"**\n- Worktree or directory already exists at that path\n- Remove existing directory or choose different name\n\n**\"branch already exists\"**\n- Branch was created previously\n- Use without `-b` flag: `git worktree add <path> <existing-branch>`\n\n**\"Cannot create worktree from detached HEAD\"**\n- Must be on a branch in main repo\n- Run `git checkout main` first\n",
+      "evalCount": 0,
+      "assertionCount": 0,
+      "hasFixtures": false,
+      "evals": [],
+      "workflows": [
+        "cleanup",
+        "create",
+        "from-linear",
+        "list",
+        "switch"
+      ],
+      "lastModified": "2026-03-01"
+    },
+    "writing-skills": {
+      "name": "writing-skills",
+      "command": "/writing-skills",
+      "description": "Use when creating new golem-powers skills, editing existing skills, or verifying skills work. Covers create skill, write skill, skill template, skill structure. NOT for: using existing skills (invoke them directly), superpowers skills (different structure).",
+      "category": "Quality",
+      "content": "\n# Writing Golem-Powers Skills\n\n> Meta-skill for creating executable skills. Skills are tools that Claude can invoke and automatically execute.\n\n## Skill Structure\n\nEvery golem-powers skill MUST have this structure:\n\n```\nskills/golem-powers/<skill-name>/\n├── SKILL.md              # REQUIRED: Frontmatter + documentation\n├── CLAUDE.md             # OPTIONAL: Environment requirements, complex setup\n├── scripts/              # REQUIRED: Executable files\n│   ├── default.sh        # Pattern A: Bash script\n│   └── run.sh            # Pattern B: Wrapper for TypeScript\n├── src/                  # OPTIONAL: TypeScript source (Pattern B)\n│   └── index.ts\n├── package.json          # OPTIONAL: Required if using TypeScript\n├── bun.lock              # OPTIONAL: Required if using TypeScript\n└── workflows/            # OPTIONAL: Multi-step procedures\n    ├── create.md\n    └── verify.md\n```\n\n### SKILL.md Frontmatter (REQUIRED)\n\n```yaml\n---\nname: <skill-name>\ndescription: <when to use this skill - shown in skill discovery>\nexecute: scripts/default.sh  # Path to script Claude runs on invocation\n---\n```\n\nThe `execute:` field is what makes a skill executable. When Claude loads a skill with `execute:` frontmatter, it MUST run that script IMMEDIATELY via Bash before any other action.\n\n---\n\n## Dual Execution Patterns\n\n### Pattern A: Bash Script\n\nBest for: Simple CLI wrappers, no dependencies, quick operations.\n\n**Frontmatter:**\n```yaml\nexecute: scripts/review.sh\n```\n\n**Structure:**\n```\nskill-name/\n├── SKILL.md\n└── scripts/\n    └── review.sh    # chmod +x\n```\n\n**Script conventions:**\n- Scripts output Markdown for Claude to parse\n- Use `set -euo pipefail` for safety\n- Exit 0 on success, non-zero on failure\n- Print errors to stderr, results to stdout\n- **MUST use BASH_SOURCE for path detection** (see Path Standard below)\n\n**Example script:**\n```bash\n#!/usr/bin/env bash\nset -euo pipefail\n\n# REQUIRED: Self-detect script location (works from any cwd)\nSCRIPT_DIR=\"$(cd \"$(dirname \"${BASH_SOURCE[0]}\")\" && pwd)\"\nSKILL_DIR=\"$(dirname \"$SCRIPT_DIR\")\"\n\necho \"## Review Results\"\necho \"\"\nsome-cli-tool review --format markdown\n```\n\n---\n\n### Pattern B: TypeScript/Bun\n\nBest for: Complex logic, API calls, type safety, structured data processing.\n\n**Frontmatter:**\n```yaml\nexecute: scripts/run.sh --action=default\n```\n\n**Structure:**\n```\nskill-name/\n├── SKILL.md\n├── scripts/\n│   └── run.sh       # Wrapper that calls bun\n├── src/\n│   └── index.ts     # Main TypeScript file\n├── package.json\n└── bun.lock\n```\n\n**The wrapper script (scripts/run.sh):**\n```bash\n#!/usr/bin/env bash\nset -euo pipefail\n\n# REQUIRED: Self-detect script location (works from any cwd)\nSCRIPT_DIR=\"$(cd \"$(dirname \"${BASH_SOURCE[0]}\")\" && pwd)\"\nSKILL_DIR=\"$(dirname \"$SCRIPT_DIR\")\"\n\ncd \"$SKILL_DIR\"\nbun run src/index.ts \"$@\"\n```\n\n**TypeScript requirements:**\n- Use Bun runtime (fast, TypeScript-native)\n- Accept CLI arguments via `process.argv`\n- Output Markdown or JSON to stdout\n- Handle errors gracefully with exit codes\n\n---\n\n## CLI Pattern (for TypeScript skills)\n\nUse flags to support multiple operations in one skill:\n\n### --action Flag\n\n```bash\nexecute: scripts/run.sh --action=default\n```\n\nAvailable actions defined in your TypeScript:\n```typescript\nconst action = process.argv.find(a => a.startsWith('--action='))?.split('=')[1] || 'default';\n\nswitch (action) {\n  case 'default':\n    // Main skill behavior\n    break;\n  case 'verify':\n    // Verification mode\n    break;\n  case 'list':\n    // List mode\n    break;\n}\n```\n\n### --env Flag\n\nFor environment selection:\n```bash\nscripts/run.sh --action=deploy --env=prod\n```\n\n```typescript\nconst env = process.argv.find(a => a.startsWith('--env='))?.split('=')[1] || 'dev';\n```\n\n---\n\n## Execution Rule\n\n**CRITICAL:** When loading a golem-powers skill with `execute:` frontmatter, Claude MUST run that script IMMEDIATELY via Bash before any other action.\n\nThis means:\n1. Claude loads the skill SKILL.md\n2. Claude sees `execute: scripts/foo.sh`\n3. Claude IMMEDIATELY runs `bash ~/.claude/commands/<skill>/scripts/foo.sh`\n4. Claude reads the output\n5. Only THEN does Claude proceed with other actions\n\nThis ensures skills are executable tools, not just documentation.\n\n---\n\n## Quick Actions\n\n| What you want | Workflow |\n|---------------|----------|\n| Create a new skill | [workflows/create.md](workflows/create.md) |\n| Audit skill structure | [workflows/audit.md](workflows/audit.md) |\n\n---\n\n## Template Generator\n\nUse the included script to scaffold new skills:\n\n```bash\nbash ~/.claude/commands/writing-skills/scripts/create-skill.sh \\\n  --name=my-skill \\\n  --type=bash\n```\n\nOptions:\n- `--name=<skill-name>` (required): Name for the new skill\n- `--type=bash|typescript` (required): Execution pattern\n- `--output=<path>` (optional): Output directory (default: ./skills/golem-powers/)\n\nThis creates:\n- Pattern A (bash): `SKILL.md`, `scripts/default.sh`\n- Pattern B (typescript): `SKILL.md`, `scripts/run.sh`, `src/index.ts`, `package.json`\n\n---\n\n## Examples\n\nSee working examples in this repo:\n- `skills/golem-powers/example-bash/` - Simple bash skill\n- `skills/golem-powers/example-typescript/` - TypeScript/Bun skill\n\n---\n\n## Safety Rules\n\n1. **Always chmod +x** - All scripts must be executable\n2. **Test before commit** - Run `shellcheck` on all .sh files\n3. **Output Markdown** - Scripts should return Markdown Claude can parse\n4. **Exit codes matter** - 0 = success, non-zero = failure\n5. **Use BASH_SOURCE pattern** - All scripts MUST self-detect their location\n\n## Path Standard (CRITICAL)\n\nAll skill scripts MUST use this pattern for portability:\n\n```bash\n#!/usr/bin/env bash\nset -euo pipefail\n\n# REQUIRED: Self-detect script location (works from any cwd)\nSCRIPT_DIR=\"$(cd \"$(dirname \"${BASH_SOURCE[0]}\")\" && pwd)\"\nSKILL_DIR=\"$(dirname \"$SCRIPT_DIR\")\"\n\n# Now use absolute paths relative to skill\nsource \"$SKILL_DIR/config.sh\"  # If needed\n```\n\n**For project detection** (when script needs prd-json/, package.json, etc.):\n\n```bash\n# Walk up from cwd to find project root\nfind_project_root() {\n    local dir=\"$PWD\"\n    while [[ ! -d \"$dir/prd-json\" && \"$dir\" != \"/\" ]]; do\n        dir=\"$(dirname \"$dir\")\"\n    done\n    if [[ -d \"$dir/prd-json\" ]]; then\n        echo \"$dir\"\n    else\n        echo \"\"\n    fi\n}\n\nPROJECT_ROOT=\"$(find_project_root)\"\nif [[ -z \"$PROJECT_ROOT\" ]]; then\n    echo \"Error: Cannot find prd-json/ directory\" >&2\n    exit 1\nfi\n```\n\n**Why this matters:**\n- Skills are symlinked in `~/.claude/commands/` but users run Claude from project directories\n- Relative paths like `./scripts/foo.sh` fail when cwd != skill directory\n- BASH_SOURCE provides reliable self-location regardless of invocation context\n\nSee `contexts/skill-authoring.md` for full details.\n",
+      "evalCount": 3,
+      "assertionCount": 10,
+      "hasFixtures": false,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 4,
+          "assertions": [
+            "follows-skill-anatomy",
+            "includes-not-for-section",
+            "checks-for-duplicates",
+            "validates-against-template"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "reads-before-editing",
+            "identifies-specific-issues",
+            "preserves-existing-structure"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "audits-all-sections",
+            "checks-references",
+            "provides-actionable-fixes"
+          ]
+        }
+      ],
+      "workflows": [
+        "audit",
+        "create"
+      ],
+      "lastModified": "2026-03-06"
+    },
+    "youtube-pipeline": {
+      "name": "youtube-pipeline",
+      "command": "/youtube-pipeline",
+      "description": "Extract knowledge from YouTube videos into BrainLayer. Use when user shares a YouTube link or asks to process/watch/extract from a video. Chains exa (transcript) -> brain_digest (entities/relations) -> brain_store (conclusions). Works with any YouTube URL.",
+      "category": "Content & Communication",
+      "content": "\n# YouTube Pipeline\n\nExtract knowledge from YouTube videos and store permanently in BrainLayer.\n\n## Pipeline\n\n```\nYouTube URL\n    ↓\n1. exa web_search (full URL as query)\n    → title, transcript, metadata\n    ↓\n2. brain_digest (raw transcript + metadata)\n    → entities, relations, action items, decisions\n    ↓\n3. brain_store (structured conclusions)\n    → searchable knowledge forever\n```\n\n## Usage\n\nWhen user shares a YouTube link:\n\n### Step 1: Extract via Exa\n\n```\nweb_search_exa(query: \"https://youtube.com/watch?v=VIDEO_ID\", num_results: 1)\n```\n\nExa returns: title, URL, full transcript text, publish date, author.\n\n**IMPORTANT:** `WebFetch` does NOT work for YouTube. Always use exa.\n\n### Step 2: Digest raw content\n\n```\nbrain_digest(content: \"<title>\\n<author>\\n<date>\\n\\n<full transcript text>\")\n```\n\nThis extracts: entities (people, tools, companies), relations, sentiment, action items, decisions, questions. Creates a searchable chunk with `source='digest'`.\n\n### Step 3: Store conclusions\n\n```\nbrain_store(\n  content: \"Video: '<title>' by <author> (<date>)\\nURL: <url>\\n\\nKey findings:\\n1. ...\\n2. ...\\n3. ...\\n\\nAction items:\\n- ...\\n\\nRelevant to: <projects>\",\n  tags: [\"youtube\", \"<author-slug>\", \"<topic-tags>\"],\n  importance: 6-8\n)\n```\n\n### Step 4: Report to user\n\nSummarize:\n- Video title and author\n- Top 3-5 key takeaways\n- Action items (things to build/try/investigate)\n- How it connects to current projects\n- BrainLayer chunk IDs for future reference\n\n## Batch Mode\n\nFor multiple videos (e.g., a playlist or \"process these 5 videos\"):\n\n1. Run exa searches in parallel (up to 5 concurrent)\n2. Digest each transcript\n3. Store individual conclusions + one synthesis\n4. Report all findings in a single summary\n\n## Tag Convention\n\n| Tag | When |\n|-----|------|\n| `youtube` | Always |\n| `<author-slug>` | e.g., `theo-browne`, `matt-pocock`, `primeagen` |\n| `<topic>` | e.g., `ai-agents`, `typescript`, `rust`, `career` |\n| `<project>` | If directly relevant: `golem-terminal`, `voicelayer`, etc. |\n\n## Tips\n\n- Exa sometimes returns partial transcripts for very long videos (3h+). Note this in the summary.\n- For livestreams/podcasts, extract the segments that matter — don't store 3 hours of chat.\n- If exa returns no transcript, try `web_search_exa(\"<video title> transcript\")` as fallback.\n- Cross-reference findings with existing BrainLayer knowledge: `brain_search(\"<key topic>\")` before storing to avoid duplicates.\n",
+      "evalCount": 3,
+      "assertionCount": 10,
+      "hasFixtures": true,
+      "evals": [
+        {
+          "name": "eval-1",
+          "assertionCount": 4,
+          "assertions": [
+            "uses-exa-not-webfetch",
+            "calls-brain-digest-on-transcript",
+            "calls-brain-store-with-youtube-tag",
+            "includes-author-slug-tag"
+          ]
+        },
+        {
+          "name": "eval-2",
+          "assertionCount": 3,
+          "assertions": [
+            "follows-three-step-pipeline",
+            "stores-structured-conclusions",
+            "reports-project-connections"
+          ]
+        },
+        {
+          "name": "eval-3",
+          "assertionCount": 3,
+          "assertions": [
+            "parallel-exa-searches",
+            "individual-brain-stores",
+            "synthesis-store"
+          ]
+        }
+      ],
+      "workflows": [],
+      "lastModified": "2026-03-06"
+    }
+  }
+}

--- a/app/(golems)/golems/skills/[name]/page.tsx
+++ b/app/(golems)/golems/skills/[name]/page.tsx
@@ -1,0 +1,363 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { MDXRemote } from "next-mdx-remote/rsc";
+import remarkGfm from "remark-gfm";
+import rehypePrettyCode from "rehype-pretty-code";
+import rehypeSlug from "rehype-slug";
+import { useMDXComponents } from "@/mdx-components";
+import CopyButton from "../../components/CopyButton";
+import MermaidDiagram from "../../components/MermaidDiagram";
+import skillsManifest from "../../lib/skills-manifest.json";
+
+interface SkillEvalEntry {
+  name: string;
+  assertionCount: number;
+  assertions: string[];
+}
+
+interface SkillData {
+  name: string;
+  command: string;
+  description: string;
+  category: string;
+  content: string;
+  evalCount: number;
+  assertionCount: number;
+  hasFixtures: boolean;
+  evals: SkillEvalEntry[];
+  workflows: string[];
+  lastModified: string;
+}
+
+const skills = skillsManifest.skills as Record<string, SkillData>;
+
+export function generateStaticParams() {
+  return Object.keys(skills).map((name) => ({ name }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ name: string }>;
+}) {
+  const { name } = await params;
+  const skill = skills[name];
+  if (!skill) return { title: "Skill Not Found" };
+  return {
+    title: `/${skill.name} — Golem Skill`,
+    description: skill.description,
+  };
+}
+
+/* ── Markdown helpers ──────────────────────────────────────── */
+
+function extractTextContent(node: React.ReactNode): string {
+  if (typeof node === "string") return node;
+  if (typeof node === "number") return String(node);
+  if (!node) return "";
+  if (Array.isArray(node)) return node.map(extractTextContent).join("");
+  if (typeof node === "object" && "props" in node) {
+    const el = node as React.ReactElement<{ children?: React.ReactNode }>;
+    return extractTextContent(el.props.children);
+  }
+  return "";
+}
+
+/* ── Category badge colors ─────────────────────────────────── */
+
+const CATEGORY_COLORS: Record<string, { bg: string; text: string }> = {
+  Development: { bg: "bg-[#6ab0f318]", text: "text-[#6ab0f3]" },
+  Operations: { bg: "bg-[#e5950018]", text: "text-[#e59500]" },
+  "Research & Context": { bg: "bg-[#40d4d418]", text: "text-[#40d4d4]" },
+  "Content & Communication": { bg: "bg-[#c084fc18]", text: "text-[#c084fc]" },
+  Quality: { bg: "bg-[#28c84018]", text: "text-[#28c840]" },
+  Domain: { bg: "bg-[#ff7eb318]", text: "text-[#ff7eb3]" },
+  Other: { bg: "bg-[#8b735518]", text: "text-[#8b7355]" },
+};
+
+/* ── Install prompt generator ──────────────────────────────── */
+
+function getInstallPrompt(skill: SkillData): string {
+  return `Install and configure the ${skill.name} skill for Claude Code.
+Download from github.com/EtanHey/golems/tree/master/skills/golem-powers/${skill.name}
+and symlink to ~/.claude/commands/${skill.name}/. If ~/.golems/config.yaml
+doesn't exist, run the setup wizard first. Then follow the First-Time
+Setup section in the SKILL.md.`;
+}
+
+/* ── Page ──────────────────────────────────────────────────── */
+
+export default async function SkillDetailPage({
+  params,
+}: {
+  params: Promise<{ name: string }>;
+}) {
+  const { name } = await params;
+  const skill = skills[name];
+  if (!skill) notFound();
+
+  const catColors = CATEGORY_COLORS[skill.category] || CATEGORY_COLORS.Other;
+  const installPrompt = getInstallPrompt(skill);
+
+  // Strip first H1 if it matches the skill name
+  const strippedContent = skill.content.replace(/^#\s+.+\n?/m, "");
+
+  const baseComponents = useMDXComponents({});
+  const components = {
+    ...baseComponents,
+    pre: ({
+      children,
+      ...props
+    }: React.ComponentPropsWithoutRef<"pre"> & {
+      children?: React.ReactNode;
+      "data-language"?: string;
+    }) => {
+      const child = children as
+        | React.ReactElement<{
+            className?: string;
+            children?: React.ReactNode;
+          }>
+        | undefined;
+      const lang =
+        props["data-language"] ||
+        child?.props?.className?.replace("language-", "");
+      if (lang === "mermaid") {
+        const chart = extractTextContent(children);
+        return <MermaidDiagram chart={chart} />;
+      }
+      const codeText = extractTextContent(children);
+      return (
+        <div className="group relative mb-4">
+          <pre
+            className="scrollbar-none overflow-x-auto rounded-lg border border-[#e5950026] bg-[#0d0d0d] p-4 text-sm [&_code]:bg-transparent [&_code]:p-0 [&_code]:text-[inherit]"
+            style={{
+              fontFamily:
+                "var(--font-golems-mono), 'JetBrains Mono', 'Fira Code', monospace",
+            }}
+            {...props}
+          >
+            {children}
+          </pre>
+          {codeText.trim() && <CopyButton text={codeText} />}
+        </div>
+      );
+    },
+  };
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 pt-6 pb-16 md:px-6 md:pt-10">
+      {/* Back link */}
+      <Link
+        href="/golems#skills"
+        className="mb-6 inline-flex items-center gap-1.5 text-sm text-[#8b7355] transition-colors hover:text-[#e59500]"
+      >
+        <svg
+          className="h-4 w-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15 19l-7-7 7-7"
+          />
+        </svg>
+        Skills Library
+      </Link>
+
+      {/* Header */}
+      <header className="mb-8">
+        <div className="mb-3 flex flex-wrap items-center gap-3">
+          <h1 className="font-mono text-3xl font-bold text-[#f0ebe0] md:text-4xl">
+            {skill.command}
+          </h1>
+          <span
+            className={`rounded-full px-3 py-1 text-xs font-medium ${catColors.bg} ${catColors.text}`}
+          >
+            {skill.category}
+          </span>
+        </div>
+        <p className="max-w-2xl text-base leading-relaxed text-[#908575]">
+          {skill.description}
+        </p>
+      </header>
+
+      {/* Trust signals */}
+      <div className="mb-10 flex flex-wrap gap-3">
+        {skill.evalCount > 0 && (
+          <div className="flex items-center gap-2 rounded-lg border border-[#28c84020] bg-[#28c84008] px-3.5 py-2">
+            <span className="inline-block h-2 w-2 rounded-full bg-[#28c840]" />
+            <span className="text-sm font-medium text-[#28c840]">
+              {skill.evalCount} evals
+            </span>
+          </div>
+        )}
+        {skill.assertionCount > 0 && (
+          <div className="flex items-center gap-2 rounded-lg border border-[#6ab0f320] bg-[#6ab0f308] px-3.5 py-2">
+            <span className="inline-block h-2 w-2 rounded-full bg-[#6ab0f3]" />
+            <span className="text-sm font-medium text-[#6ab0f3]">
+              {skill.assertionCount} assertions
+            </span>
+          </div>
+        )}
+        {skill.hasFixtures && (
+          <div className="flex items-center gap-2 rounded-lg border border-[#e5950020] bg-[#e5950008] px-3.5 py-2">
+            <span className="inline-block h-2 w-2 rounded-full bg-[#e59500]" />
+            <span className="text-sm font-medium text-[#e59500]">fixtures</span>
+          </div>
+        )}
+        {skill.workflows.length > 0 && (
+          <div className="flex items-center gap-2 rounded-lg border border-[#c084fc20] bg-[#c084fc08] px-3.5 py-2">
+            <span className="inline-block h-2 w-2 rounded-full bg-[#c084fc]" />
+            <span className="text-sm font-medium text-[#c084fc]">
+              {skill.workflows.length} workflows
+            </span>
+          </div>
+        )}
+        <div className="flex items-center gap-2 rounded-lg border border-[#8b735520] bg-[#8b735508] px-3.5 py-2">
+          <span className="text-sm text-[#8b7355]">
+            Updated {skill.lastModified}
+          </span>
+        </div>
+      </div>
+
+      {/* SKILL.md content */}
+      <section className="mb-12">
+        <MDXRemote
+          source={strippedContent}
+          components={components}
+          options={{
+            mdxOptions: {
+              format: "md",
+              remarkPlugins: [remarkGfm],
+              rehypePlugins: [
+                rehypeSlug,
+                [
+                  rehypePrettyCode,
+                  { theme: "github-dark-dimmed", keepBackground: false },
+                ],
+              ],
+            },
+          }}
+        />
+      </section>
+
+      {/* Eval Results */}
+      {skill.evals.length > 0 && (
+        <section className="mb-12">
+          <h2 className="mb-4 text-xl font-bold text-[#f0ebe0]">
+            Eval Results
+          </h2>
+          <div className="overflow-hidden rounded-xl border border-[#e5950020] bg-[#14120e]/90">
+            {skill.evals.map((evalItem, i) => (
+              <div
+                key={evalItem.name}
+                className={`flex items-start gap-4 px-5 py-4 ${i > 0 ? "border-t border-[#e5950014]" : ""}`}
+              >
+                <div className="flex-1">
+                  <div className="mb-1 flex items-center gap-2">
+                    <span className="font-mono text-sm font-medium text-[#c0b8a8]">
+                      {evalItem.name}
+                    </span>
+                    <span className="rounded-full bg-[#6ab0f315] px-2 py-0.5 text-[0.65rem] font-medium text-[#6ab0f3]">
+                      {evalItem.assertionCount} assertions
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {evalItem.assertions.map((a) => (
+                      <span
+                        key={a}
+                        className="rounded bg-[#28c84010] px-2 py-0.5 font-mono text-[0.65rem] text-[#28c840]/80"
+                      >
+                        {a}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Workflows */}
+      {skill.workflows.length > 0 && (
+        <section className="mb-12">
+          <h2 className="mb-4 text-xl font-bold text-[#f0ebe0]">Workflows</h2>
+          <div className="flex flex-wrap gap-2">
+            {skill.workflows.map((w) => (
+              <span
+                key={w}
+                className="rounded-lg border border-[#c084fc20] bg-[#c084fc08] px-4 py-2 font-mono text-sm text-[#c084fc]"
+              >
+                {skill.command}:{w}
+              </span>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Install Prompt */}
+      <section className="mb-12">
+        <h2 className="mb-4 text-xl font-bold text-[#f0ebe0]">Install</h2>
+        <div className="rounded-xl border border-[#2dd4a826] bg-[#14120e]/90 p-5">
+          <p className="mb-3 text-sm text-[#7c6f5e]">
+            Paste this into any Claude Code session:
+          </p>
+          <div className="group relative">
+            <CopyButton text={installPrompt} />
+            <pre className="scrollbar-none overflow-x-auto rounded-lg border border-[#2dd4a81a] bg-black/40 p-4 font-mono text-sm leading-relaxed text-[#2dd4a8]">
+              {installPrompt}
+            </pre>
+          </div>
+        </div>
+      </section>
+
+      {/* Source link */}
+      <div className="flex flex-wrap items-center justify-between gap-4 border-t border-[#e5950020] pt-6">
+        <Link
+          href="/golems#skills"
+          className="inline-flex items-center gap-1.5 text-sm text-[#8b7355] transition-colors hover:text-[#e59500]"
+        >
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+          Back to Skills Library
+        </Link>
+        <a
+          href={`https://github.com/EtanHey/golems/tree/master/skills/golem-powers/${skill.name}`}
+          className="inline-flex items-center gap-1.5 text-sm text-[#8b7355] transition-colors hover:text-[#c0b8a8]"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          View on GitHub
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+            />
+          </svg>
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/docs/plans/2026-03-10-skill-detail-pages.md
+++ b/docs/plans/2026-03-10-skill-detail-pages.md
@@ -1,0 +1,233 @@
+# Skill Detail Pages Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build `/golems/skills/[name]` detail pages that render SKILL.md content, eval results, install prompt, and trust signals for each of the 55 golem skills.
+
+**Architecture:** Generate a skills manifest JSON from the golems repo (reads SKILL.md + evals.json per skill). Server component renders each skill page using MDXRemote for markdown content. SkillCards in the existing SkillsShowcase become links to detail pages.
+
+**Tech Stack:** Next.js 15 server components, MDXRemote, gray-matter, existing golems design system (dark theme, amber/green accents).
+
+---
+
+### Task 1: Generate Skills Manifest Script
+
+**Files:**
+- Create: `scripts/generate-skills-manifest.ts`
+- Create: `app/(golems)/golems/lib/skills-manifest.json`
+
+**Step 1: Write the manifest generation script**
+
+```typescript
+// scripts/generate-skills-manifest.ts
+import { readFileSync, readdirSync, statSync, existsSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import matter from 'gray-matter';
+
+const SKILLS_DIR = join(process.env.HOME || '~', 'Gits/golems/skills/golem-powers');
+const OUTPUT = join(__dirname, '../app/(golems)/golems/lib/skills-manifest.json');
+
+// Category map from SkillsShowcase.tsx (reuse exactly)
+const CATEGORY_MAP: Record<string, string> = {
+  commit: 'Development', 'pr-loop': 'Development', worktrees: 'Development',
+  'test-plan': 'Development', lsp: 'Development', coderabbit: 'Development',
+  'critique-waves': 'Development',
+  'cmux-agents': 'Operations', cmux: 'Operations', railway: 'Operations',
+  '1password': 'Operations', github: 'Operations', convex: 'Operations',
+  'golem-install': 'Operations',
+  brainlayer: 'Research & Context', research: 'Research & Context',
+  context7: 'Research & Context', 'github-research': 'Research & Context',
+  catchup: 'Research & Context', obsidian: 'Research & Context',
+  content: 'Content & Communication', 'voice-sessions': 'Content & Communication',
+  'video-showcase': 'Content & Communication', 'presentation-builder': 'Content & Communication',
+  'youtube-pipeline': 'Content & Communication',
+  'never-fabricate': 'Quality', 'large-plan': 'Quality', archive: 'Quality',
+  'writing-skills': 'Quality', skills: 'Quality',
+  coach: 'Domain', 'interview-practice': 'Domain', prd: 'Domain',
+  brave: 'Domain', 'figma-loop': 'Domain', 'cli-agents': 'Domain',
+};
+
+interface SkillEval {
+  id: number;
+  name?: string;
+  prompt: string;
+  expected_output: string;
+  assertions: { name: string; description: string; type?: string }[];
+}
+
+interface SkillManifestEntry {
+  name: string;
+  command: string;
+  description: string;
+  category: string;
+  content: string;         // raw SKILL.md markdown (without frontmatter)
+  frontmatter: Record<string, unknown>;
+  evalCount: number;
+  assertionCount: number;
+  hasFixtures: boolean;
+  evals: { name: string; assertionCount: number; assertions: string[] }[];
+  workflows: string[];
+  lastModified: string;
+}
+
+function generateManifest() {
+  const skills: Record<string, SkillManifestEntry> = {};
+  const dirs = readdirSync(SKILLS_DIR).filter(d =>
+    statSync(join(SKILLS_DIR, d)).isDirectory()
+  );
+
+  for (const dir of dirs) {
+    const skillDir = join(SKILLS_DIR, dir);
+    const skillMdPath = join(skillDir, 'SKILL.md');
+    if (!existsSync(skillMdPath)) continue;
+
+    const raw = readFileSync(skillMdPath, 'utf-8');
+    const { data: frontmatter, content } = matter(raw);
+
+    // Read evals
+    const evalsPath = join(skillDir, 'evals', 'evals.json');
+    let evalData: SkillEval[] = [];
+    let hasFixtures = false;
+    if (existsSync(evalsPath)) {
+      const evalsRaw = JSON.parse(readFileSync(evalsPath, 'utf-8'));
+      evalData = evalsRaw.evals || [];
+      hasFixtures = existsSync(join(skillDir, 'evals', 'fixtures'));
+    }
+
+    // Read workflows
+    const workflowsDir = join(skillDir, 'workflows');
+    const workflows = existsSync(workflowsDir)
+      ? readdirSync(workflowsDir).filter(f => f.endsWith('.md')).map(f => f.replace('.md', ''))
+      : [];
+
+    const totalAssertions = evalData.reduce((sum, e) => sum + (e.assertions?.length || 0), 0);
+
+    skills[dir] = {
+      name: dir,
+      command: `/${dir}`,
+      description: frontmatter.description || content.match(/^[^#\n].+/m)?.[0]?.trim() || '',
+      category: CATEGORY_MAP[dir] || 'Other',
+      content,
+      frontmatter,
+      evalCount: evalData.length,
+      assertionCount: totalAssertions,
+      hasFixtures,
+      evals: evalData.map((e, i) => ({
+        name: e.name || `eval-${i + 1}`,
+        assertionCount: e.assertions?.length || 0,
+        assertions: (e.assertions || []).map(a => a.name),
+      })),
+      workflows,
+      lastModified: statSync(skillMdPath).mtime.toISOString().split('T')[0],
+    };
+  }
+
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    skillCount: Object.keys(skills).length,
+    skills,
+  };
+
+  writeFileSync(OUTPUT, JSON.stringify(manifest, null, 2));
+  console.log(`Generated manifest: ${Object.keys(skills).length} skills → ${OUTPUT}`);
+}
+
+generateManifest();
+```
+
+**Step 2: Run the script to generate manifest**
+
+Run: `cd /Users/etanheyman/Gits/etanheyman.com && npx tsx scripts/generate-skills-manifest.ts`
+Expected: "Generated manifest: ~54 skills → .../skills-manifest.json"
+
+**Step 3: Verify manifest looks correct**
+
+Read the generated `skills-manifest.json` and spot-check a few entries (commit, coach, cmux-agents).
+
+---
+
+### Task 2: Create Skill Detail Page
+
+**Files:**
+- Create: `app/(golems)/golems/skills/[name]/page.tsx`
+
+**Step 1: Write the page component**
+
+Server component that:
+1. Reads skill from manifest by `name` param
+2. Returns `notFound()` if skill doesn't exist
+3. Renders: header with trust signals, SKILL.md content via MDXRemote, eval results table, install prompt
+4. Uses existing design patterns (dark theme, amber/green accents, CopyButton)
+
+Key sections:
+- **Header**: Skill name (as command), category badge, description
+- **Trust signals bar**: eval count, assertion count, fixtures badge, last modified date
+- **SKILL.md content**: Rendered via MDXRemote with same options as docs pages
+- **Eval Results**: Table showing each eval case with assertion count and assertion names
+- **Install Prompt**: Copyable block
+- **Back link**: Returns to golems page (skills section)
+
+**Step 2: Generate metadata**
+
+```typescript
+export async function generateMetadata({ params }) {
+  // Read from manifest, return title + description
+}
+```
+
+**Step 3: Add generateStaticParams**
+
+```typescript
+export function generateStaticParams() {
+  // Return all skill names from manifest for static generation
+}
+```
+
+**Step 4: Verify the page renders**
+
+Run: `npm run dev -- -p 3001` (no turbopack)
+Visit: `http://localhost:3001/golems/skills/commit`
+Expected: Full skill detail page with SKILL.md content, eval badges, install prompt.
+
+---
+
+### Task 3: Link SkillCards to Detail Pages
+
+**Files:**
+- Modify: `app/(golems)/golems/components/SkillsShowcase.tsx`
+
+**Step 1: Add Link import and wrap SkillCard**
+
+In `SkillCard` component, wrap the outer div in a `<Link href={`/golems/skills/${skill.name}`}>` so each card navigates to the detail page.
+
+**Step 2: Verify navigation works**
+
+Click a skill card in the SkillsShowcase → should navigate to `/golems/skills/{name}`.
+
+---
+
+### Task 4: Build & Verify
+
+**Step 1: Run build**
+
+Run: `npm run build`
+Expected: All skill pages statically generated, no errors.
+
+**Step 2: Verify several pages**
+
+Check at least: `/golems/skills/commit`, `/golems/skills/coach`, `/golems/skills/cmux-agents`
+Each should show: rendered SKILL.md, eval results, install prompt, trust signals.
+
+**Step 3: Commit**
+
+```bash
+git checkout -b feat/skill-detail-pages
+git add scripts/generate-skills-manifest.ts app/(golems)/golems/lib/skills-manifest.json app/(golems)/golems/skills/
+git commit -m "feat: add skill detail pages with eval results and install prompts"
+```
+
+---
+
+### Task 5: PR via /pr-loop
+
+Use `/pr-loop` to create PR, get review, fix issues, merge.

--- a/scripts/generate-skills-manifest.ts
+++ b/scripts/generate-skills-manifest.ts
@@ -1,0 +1,162 @@
+import {
+  readFileSync,
+  readdirSync,
+  statSync,
+  existsSync,
+  writeFileSync,
+} from "fs";
+import { join } from "path";
+import matter from "gray-matter";
+
+const SKILLS_DIR = join(
+  process.env.HOME || "",
+  "Gits/golems/skills/golem-powers",
+);
+const OUTPUT = join(
+  __dirname,
+  "../app/(golems)/golems/lib/skills-manifest.json",
+);
+
+const CATEGORY_MAP: Record<string, string> = {
+  commit: "Development",
+  "pr-loop": "Development",
+  worktrees: "Development",
+  "test-plan": "Development",
+  lsp: "Development",
+  coderabbit: "Development",
+  "critique-waves": "Development",
+  "cmux-agents": "Operations",
+  cmux: "Operations",
+  railway: "Operations",
+  "1password": "Operations",
+  github: "Operations",
+  convex: "Operations",
+  "golem-install": "Operations",
+  brainlayer: "Research & Context",
+  research: "Research & Context",
+  context7: "Research & Context",
+  "github-research": "Research & Context",
+  catchup: "Research & Context",
+  obsidian: "Research & Context",
+  content: "Content & Communication",
+  "voice-sessions": "Content & Communication",
+  "video-showcase": "Content & Communication",
+  "presentation-builder": "Content & Communication",
+  "youtube-pipeline": "Content & Communication",
+  "never-fabricate": "Quality",
+  "large-plan": "Quality",
+  archive: "Quality",
+  "writing-skills": "Quality",
+  skills: "Quality",
+  coach: "Domain",
+  "interview-practice": "Domain",
+  prd: "Domain",
+  brave: "Domain",
+  "figma-loop": "Domain",
+  "cli-agents": "Domain",
+};
+
+interface SkillEvalAssertion {
+  name: string;
+  description: string;
+  type?: string;
+}
+
+interface SkillEval {
+  id: number;
+  name?: string;
+  prompt: string;
+  expected_output: string;
+  assertions: SkillEvalAssertion[];
+}
+
+function generateManifest() {
+  const skills: Record<string, unknown> = {};
+  const dirs = readdirSync(SKILLS_DIR).filter((d) =>
+    statSync(join(SKILLS_DIR, d)).isDirectory(),
+  );
+
+  for (const dir of dirs) {
+    const skillDir = join(SKILLS_DIR, dir);
+    const skillMdPath = join(skillDir, "SKILL.md");
+    if (!existsSync(skillMdPath)) continue;
+
+    const raw = readFileSync(skillMdPath, "utf-8");
+    let frontmatter: Record<string, unknown> = {};
+    let content = raw;
+    try {
+      const parsed = matter(raw);
+      frontmatter = parsed.data;
+      content = parsed.content;
+    } catch {
+      // Malformed YAML frontmatter — strip it manually
+      const fmMatch = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+      if (fmMatch) {
+        content = fmMatch[2];
+        // Try to extract name/description from the raw YAML lines
+        const nameMatch = fmMatch[1].match(/^name:\s*(.+)$/m);
+        const descMatch = fmMatch[1].match(/^description:\s*(.+)$/m);
+        if (nameMatch) frontmatter.name = nameMatch[1].trim();
+        if (descMatch) frontmatter.description = descMatch[1].trim();
+      }
+    }
+
+    // Read evals
+    const evalsPath = join(skillDir, "evals", "evals.json");
+    let evalData: SkillEval[] = [];
+    let hasFixtures = false;
+    if (existsSync(evalsPath)) {
+      const evalsRaw = JSON.parse(readFileSync(evalsPath, "utf-8"));
+      evalData = evalsRaw.evals || [];
+      hasFixtures = existsSync(join(skillDir, "evals", "fixtures"));
+    }
+
+    // Read workflows
+    const workflowsDir = join(skillDir, "workflows");
+    const workflows = existsSync(workflowsDir)
+      ? readdirSync(workflowsDir)
+          .filter((f) => f.endsWith(".md"))
+          .map((f) => f.replace(".md", ""))
+      : [];
+
+    const totalAssertions = evalData.reduce(
+      (sum, e) => sum + (e.assertions?.length || 0),
+      0,
+    );
+
+    // Extract first non-heading, non-empty line as description fallback
+    const descriptionFallback =
+      content.match(/^(?!#|\s*$).+/m)?.[0]?.trim() || "";
+
+    skills[dir] = {
+      name: dir,
+      command: `/${dir}`,
+      description: (frontmatter.description as string) || descriptionFallback,
+      category: CATEGORY_MAP[dir] || "Other",
+      content,
+      evalCount: evalData.length,
+      assertionCount: totalAssertions,
+      hasFixtures,
+      evals: evalData.map((e, i) => ({
+        name: e.name || `eval-${i + 1}`,
+        assertionCount: e.assertions?.length || 0,
+        assertions: (e.assertions || []).map((a) => a.name),
+      })),
+      workflows,
+      lastModified: statSync(skillMdPath).mtime.toISOString().split("T")[0],
+    };
+  }
+
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    skillCount: Object.keys(skills).length,
+    skills,
+  };
+
+  writeFileSync(OUTPUT, JSON.stringify(manifest, null, 2));
+  console.log(
+    `Generated manifest: ${Object.keys(skills).length} skills → ${OUTPUT}`,
+  );
+}
+
+generateManifest();


### PR DESCRIPTION
## Summary
- **55 dynamic pages** at `/golems/skills/[name]` — each skill gets a full detail page
- **Skills manifest generator** (`scripts/generate-skills-manifest.ts`) reads SKILL.md + evals from golems repo
- **Trust signals**: eval count, assertion count, fixtures badge, workflow count, last modified date
- **Eval results table** with per-eval assertion breakdown (assertion names as tags)
- **Copyable install prompt** for each skill
- **SkillCards now link** to detail pages from the SkillsShowcase grid
- **GitHub source link** per skill

## What each skill page shows
1. Header with skill command name, category badge, description
2. Trust signal badges (evals, assertions, fixtures, workflows, last updated)
3. Full SKILL.md content rendered as markdown (via MDXRemote format:md)
4. Eval results section with assertion breakdown per eval case
5. Workflows section (if skill has workflow sub-commands)
6. Install prompt (copyable one-liner)
7. Back to Skills Library + View on GitHub links

## Test plan
- [x] `bun run build` passes — all 55 skill pages statically generated
- [x] Dev server: `/golems/skills/commit` → 200
- [x] Dev server: `/golems/skills/coach` → 200
- [x] Dev server: `/golems/skills/cmux-agents` → 200
- [x] Dev server: `/golems/skills/nonexistent` → 404
- [x] All content sections render (verified via curl)
- [x] 10/10 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Skill cards in the Skills Library are now clickable and navigate to dedicated detail pages.
* Added comprehensive skill detail pages featuring skill metadata, category badges, evaluation results, trust signals, installation instructions, workflow information, and quick-access links for each skill.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->