### PR TITLE
fix: prevent logo/portrait images from being cropped in cards

### DIFF
--- a/app/components/ProjectCard.tsx
+++ b/app/components/ProjectCard.tsx
@@ -116,8 +116,7 @@ function getProjectAccent(project: Project): AccentName {
 function isSvgOrLogoAsset(imageUrl: string | null): imageUrl is string {
   if (!imageUrl) return false;
   return (
-    (imageUrl.toLowerCase().endsWith(".svg") &&
-      !imageUrl.includes("hand-detection")) ||
+    imageUrl.toLowerCase().endsWith(".svg") ||
     imageUrl.includes("#svg") ||
     imageUrl.includes("#logo")
   );
@@ -267,7 +266,7 @@ function ProjectCardBase({
                   fill
                   priority={priority}
                   sizes={sizes}
-                  className="object-cover object-center transition-transform duration-700 group-hover/card:scale-[1.04]"
+                  className="object-contain object-center transition-transform duration-700 group-hover/card:scale-[1.04]"
                 />
               )}
             </>


### PR DESCRIPTION
## Summary
- Remove hand-detection exclusion from SVG logo detection — Hand Sign Detection card now renders with object-contain
- Change all non-logo card images from object-cover to object-contain — Golems and Casona logos no longer cropped at top/bottom
- bg-gray-900 on image zone fills gaps around contained images

## Test plan
- [x] Tests pass (10/10)
- [x] Hand Sign Detection, Golems, Casona cards show full logos without cropping

🤖 Generated with [Claude Code](https://claude.com/claude-code)