### PR TITLE
feat: redesign Hand Sign Detection logo

### DIFF
--- a/public/images/projects/hand-detection-logo.svg
+++ b/public/images/projects/hand-detection-logo.svg
@@ -1,52 +1,93 @@
-<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
-  <!-- Background -->
-  <rect width="200" height="200" rx="40" fill="#00003F"/>
+<svg width="400" height="400" viewBox="0 0 400 400" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="tip" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#fff" stop-opacity="1"/>
+      <stop offset="40%" stop-color="#88CFF8" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#0F82EB" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="g"><feGaussianBlur stdDeviation="2"/><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="bg"><feGaussianBlur stdDeviation="4.5"/><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+  </defs>
 
-  <!-- Inner glow -->
-  <rect x="10" y="10" width="180" height="180" rx="35" fill="none" stroke="#0F82EB" stroke-width="1" opacity="0.3"/>
+  <!-- === HAND SKELETON — 21 landmarks, MediaPipe layout === -->
 
-  <!-- Hand silhouette centered -->
-  <g transform="translate(100, 100)">
-    <!-- Palm -->
-    <ellipse cx="0" cy="10" rx="35" ry="40" fill="#0F82EB" opacity="0.8"/>
+  <!-- CONNECTIONS — drawn first so nodes sit on top -->
+  <!-- Wrist to each finger base (MCP) -->
+  <line x1="200" y1="340" x2="120" y2="230" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
+  <line x1="200" y1="340" x2="165" y2="210" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
+  <line x1="200" y1="340" x2="210" y2="205" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
+  <line x1="200" y1="340" x2="252" y2="215" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
+  <line x1="200" y1="340" x2="288" y2="235" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
 
-    <!-- Fingers -->
-    <!-- Thumb -->
-    <rect x="25" y="-10" width="18" height="35" rx="9" fill="#0F82EB" opacity="0.8" transform="rotate(30 25 -10)"/>
+  <!-- Palm cross-connections (MCP to MCP) -->
+  <line x1="120" y1="230" x2="165" y2="210" stroke="#2AA9F2" stroke-width="1.8" opacity="0.4"/>
+  <line x1="165" y1="210" x2="210" y2="205" stroke="#2AA9F2" stroke-width="1.8" opacity="0.4"/>
+  <line x1="210" y1="205" x2="252" y2="215" stroke="#2AA9F2" stroke-width="1.8" opacity="0.4"/>
+  <line x1="252" y1="215" x2="288" y2="235" stroke="#2AA9F2" stroke-width="1.8" opacity="0.4"/>
 
-    <!-- Index finger -->
-    <rect x="-25" y="-45" width="15" height="45" rx="7.5" fill="#0F82EB" opacity="0.8"/>
+  <!-- Thumb: CMC → MCP → IP → TIP -->
+  <line x1="120" y1="230" x2="88" y2="192" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
+  <line x1="88" y1="192" x2="62" y2="152" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
+  <line x1="62" y1="152" x2="45" y2="112" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
 
-    <!-- Middle finger -->
-    <rect x="-8" y="-50" width="15" height="50" rx="7.5" fill="#0F82EB" opacity="0.8"/>
+  <!-- Index: MCP → PIP → DIP → TIP -->
+  <line x1="165" y1="210" x2="148" y2="148" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
+  <line x1="148" y1="148" x2="138" y2="95" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
+  <line x1="138" y1="95" x2="132" y2="48" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
 
-    <!-- Ring finger -->
-    <rect x="8" y="-45" width="15" height="45" rx="7.5" fill="#0F82EB" opacity="0.8"/>
+  <!-- Middle: MCP → PIP → DIP → TIP -->
+  <line x1="210" y1="205" x2="210" y2="138" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
+  <line x1="210" y1="138" x2="210" y2="82" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
+  <line x1="210" y1="82" x2="210" y2="30" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
 
-    <!-- Pinky -->
-    <rect x="23" y="-35" width="12" height="35" rx="6" fill="#0F82EB" opacity="0.8"/>
+  <!-- Ring: MCP → PIP → DIP → TIP -->
+  <line x1="252" y1="215" x2="264" y2="148" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
+  <line x1="264" y1="148" x2="272" y2="92" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
+  <line x1="272" y1="92" x2="278" y2="42" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
 
-    <!-- Detection dots on fingertips -->
-    <circle cx="-17.5" cy="-45" r="5" fill="#88CFF8"/>
-    <circle cx="-0.5" cy="-50" r="5" fill="#88CFF8"/>
-    <circle cx="15.5" cy="-45" r="5" fill="#88CFF8"/>
-    <circle cx="29" cy="-35" r="4" fill="#88CFF8"/>
-    <circle cx="38" cy="5" r="5" fill="#88CFF8"/>
+  <!-- Pinky: MCP → PIP → DIP → TIP -->
+  <line x1="288" y1="235" x2="310" y2="172" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
+  <line x1="310" y1="172" x2="322" y2="118" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
+  <line x1="322" y1="118" x2="330" y2="68" stroke="#0F82EB" stroke-width="2.5" opacity="0.55"/>
 
-    <!-- Palm detection center -->
-    <circle cx="0" cy="10" r="6" fill="#59BCF5"/>
+  <!-- === NODES === -->
 
-    <!-- Connection lines -->
-    <line x1="-17.5" y1="-45" x2="0" y2="10" stroke="#59BCF5" stroke-width="1" opacity="0.4"/>
-    <line x1="-0.5" y1="-50" x2="0" y2="10" stroke="#59BCF5" stroke-width="1" opacity="0.4"/>
-    <line x1="15.5" y1="-45" x2="0" y2="10" stroke="#59BCF5" stroke-width="1" opacity="0.4"/>
-    <line x1="29" y1="-35" x2="0" y2="10" stroke="#59BCF5" stroke-width="1" opacity="0.4"/>
-    <line x1="38" y1="5" x2="0" y2="10" stroke="#59BCF5" stroke-width="1" opacity="0.4"/>
-  </g>
+  <!-- Wrist — large anchor -->
+  <circle cx="200" cy="340" r="10" fill="#0053A4" opacity="0.7" filter="url(#g)"/>
+  <circle cx="200" cy="340" r="5.5" fill="#0F82EB"/>
 
-  <!-- Corner indicators -->
-  <circle cx="30" cy="30" r="3" fill="#88CFF8" opacity="0.6"/>
-  <circle cx="170" cy="30" r="3" fill="#88CFF8" opacity="0.6"/>
-  <circle cx="30" cy="170" r="3" fill="#88CFF8" opacity="0.6"/>
-  <circle cx="170" cy="170" r="3" fill="#88CFF8" opacity="0.6"/>
+  <!-- Thumb nodes -->
+  <circle cx="120" cy="230" r="7" fill="#0F82EB" opacity="0.75" filter="url(#g)"/>
+  <circle cx="88" cy="192" r="6" fill="#2AA9F2" opacity="0.7"/>
+  <circle cx="62" cy="152" r="5.5" fill="#2AA9F2" opacity="0.7"/>
+  <circle cx="45" cy="112" r="12" fill="url(#tip)" filter="url(#bg)"/>
+  <circle cx="45" cy="112" r="6" fill="#59BCF5"/><circle cx="45" cy="112" r="3" fill="#fff"/>
+
+  <!-- Index nodes -->
+  <circle cx="165" cy="210" r="7" fill="#0F82EB" opacity="0.75" filter="url(#g)"/>
+  <circle cx="148" cy="148" r="6" fill="#2AA9F2" opacity="0.7"/>
+  <circle cx="138" cy="95" r="5.5" fill="#2AA9F2" opacity="0.7"/>
+  <circle cx="132" cy="48" r="13" fill="url(#tip)" filter="url(#bg)"/>
+  <circle cx="132" cy="48" r="6.5" fill="#59BCF5"/><circle cx="132" cy="48" r="3.2" fill="#fff"/>
+
+  <!-- Middle nodes -->
+  <circle cx="210" cy="205" r="7" fill="#0F82EB" opacity="0.75" filter="url(#g)"/>
+  <circle cx="210" cy="138" r="6" fill="#2AA9F2" opacity="0.7"/>
+  <circle cx="210" cy="82" r="5.5" fill="#2AA9F2" opacity="0.7"/>
+  <circle cx="210" cy="30" r="14" fill="url(#tip)" filter="url(#bg)"/>
+  <circle cx="210" cy="30" r="7" fill="#59BCF5"/><circle cx="210" cy="30" r="3.5" fill="#fff"/>
+
+  <!-- Ring nodes -->
+  <circle cx="252" cy="215" r="7" fill="#0F82EB" opacity="0.75" filter="url(#g)"/>
+  <circle cx="264" cy="148" r="6" fill="#2AA9F2" opacity="0.7"/>
+  <circle cx="272" cy="92" r="5.5" fill="#2AA9F2" opacity="0.7"/>
+  <circle cx="278" cy="42" r="13" fill="url(#tip)" filter="url(#bg)"/>
+  <circle cx="278" cy="42" r="6.5" fill="#59BCF5"/><circle cx="278" cy="42" r="3.2" fill="#fff"/>
+
+  <!-- Pinky nodes -->
+  <circle cx="288" cy="235" r="7" fill="#0F82EB" opacity="0.75" filter="url(#g)"/>
+  <circle cx="310" cy="172" r="6" fill="#2AA9F2" opacity="0.7"/>
+  <circle cx="322" cy="118" r="5.5" fill="#2AA9F2" opacity="0.7"/>
+  <circle cx="330" cy="68" r="12" fill="url(#tip)" filter="url(#bg)"/>
+  <circle cx="330" cy="68" r="6" fill="#59BCF5"/><circle cx="330" cy="68" r="3" fill="#fff"/>
 </svg>


### PR DESCRIPTION
## Summary
- Replace old boxy logo (rounded square, crude rectangles) with clean MediaPipe-style hand skeleton wireframe
- 21 landmark nodes with anatomical connections, glowing fingertips
- No container box — transparent background, works on any card bg

## Test plan
- [x] Tests pass
- [x] SVG renders correctly in card image zone

🤖 Generated with [Claude Code](https://claude.com/claude-code)