### PR TITLE
docs: update golems-stats.json — March 17 2026

### DIFF
--- a/app/(golems)/golems/lib/golems-stats.json
+++ b/app/(golems)/golems/lib/golems-stats.json
@@ -1,10 +1,11 @@
 {
-  "generatedAt": "2026-03-16T00:00:00Z",
+  "generatedAt": "2026-03-17T00:00:00Z",
   "skills": {
-    "count": 46,
-    "withSkillMd": 46,
+    "count": 45,
+    "withSkillMd": 45,
     "withEvals": 35,
-    "evalCoverage": "76%"
+    "evalCoverage": "78%",
+    "adapterLayer": "AI-agnostic (Claude, Cursor, Gemini, Codex, Kiro)"
   },
   "packages": {
     "count": 12,
@@ -18,8 +19,24 @@
     "files": 78
   },
   "brainlayer": {
-    "chunks": 297536,
-    "chunksDisplay": "297K+"
+    "chunks": 312000,
+    "chunksDisplay": "312K+",
+    "mcpTools": 8,
+    "pythonTests": 846,
+    "swiftTests": 28,
+    "daemon": "BrainBar (209KB native binary)"
+  },
+  "voicelayer": {
+    "daemon": "MCP daemon, dual-protocol (NDJSON + MCP Content-Length)"
+  },
+  "cmuxlayer": {
+    "tests": 221,
+    "socketSpeedup": "1,423x",
+    "nativeMcp": true
+  },
+  "daemons": {
+    "count": 3,
+    "list": "BrainBar, VoiceBar MCP, cmux native MCP"
   },
   "mcp": {
     "count": 8,


### PR DESCRIPTION
## Summary
- BrainLayer: 297K → 312K+ chunks, 8 MCP tools, 846 Python + 28 Swift tests, BrainBar daemon (209KB)
- VoiceLayer: added MCP daemon with dual-protocol stats
- cmuxlayer: added section (221 tests, 1,423x socket speedup, native MCP)
- Skills: 46 → 45 (consolidated), added AI-agnostic adapter layer field
- New daemons section: 3 singleton daemons (BrainBar, VoiceBar MCP, cmux native MCP)
- Note: project pages are Supabase-driven — only golems-stats.json updated here

## Test plan
- [ ] Vitest passes (10/10 confirmed)
- [ ] /golems page renders with updated stats
- [ ] New JSON fields don't break existing components

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>