### PR TITLE
fix: update stale portfolio stats

### DIFF
--- a/app/(golems)/golems/lib/golems-stats.json
+++ b/app/(golems)/golems/lib/golems-stats.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-03-17T00:00:00Z",
+  "generatedAt": "2026-03-18T00:00:00Z",
   "skills": {
-    "count": 45,
-    "withSkillMd": 45,
+    "count": 47,
+    "withSkillMd": 47,
     "withEvals": 35,
-    "evalCoverage": "78%",
+    "evalCoverage": "74%",
     "adapterLayer": "AI-agnostic (Claude, Cursor, Gemini, Codex, Kiro)"
   },
   "packages": {
@@ -19,10 +19,10 @@
     "files": 78
   },
   "brainlayer": {
-    "chunks": 312000,
-    "chunksDisplay": "312K+",
+    "chunks": 321297,
+    "chunksDisplay": "321K+",
     "mcpTools": 8,
-    "pythonTests": 846,
+    "pythonTests": 1030,
     "swiftTests": 28,
     "daemon": "BrainBar (209KB native binary)"
   },

--- a/app/(portfolio)/projects/[slug]/project-showcase-config.ts
+++ b/app/(portfolio)/projects/[slug]/project-showcase-config.ts
@@ -48,8 +48,8 @@ const configs: Record<string, ProjectShowcaseConfig> = {
     tagline: "pip install brainlayer",
     isMiniSite: true,
     stats: [
-      { value: 291, suffix: "K+", label: "Indexed chunks" },
-      { value: 7, label: "MCP tools" },
+      { value: 321, suffix: "K+", label: "Indexed chunks" },
+      { value: 8, label: "MCP tools" },
       { value: 1024, label: "Vector dimensions" },
       { value: 119, label: "KG entities" },
     ],
@@ -68,9 +68,9 @@ const configs: Record<string, ProjectShowcaseConfig> = {
       },
       {
         iconName: "Database",
-        title: "7 MCP Tools",
+        title: "8 MCP Tools",
         description:
-          "3 core (search, store, recall) + 4 knowledge graph (digest, entity, update, person lookup). Consolidated from 14 to 7. Old names still work via aliases.",
+          "3 core (search, store, recall) + 5 knowledge graph (digest, entity, update, expand, tags). Consolidated from 14 to 8. Old names still work via aliases.",
       },
       {
         iconName: "Brain",
@@ -112,7 +112,7 @@ const configs: Record<string, ProjectShowcaseConfig> = {
       { value: 2, label: "MCP tools" },
       { value: 2, label: "STT backends" },
       { value: 300, suffix: "ms", prefix: "~", label: "STT latency" },
-      { value: 236, label: "Tests passing" },
+      { value: 308, label: "Tests passing" },
     ],
     features: [
       {
@@ -299,10 +299,10 @@ const configs: Record<string, ProjectShowcaseConfig> = {
     accent: { color: "#94A3B8", colorRgb: "148, 163, 184" },
     isMiniSite: true,
     stats: [
-      { value: 11, label: "Packages" },
+      { value: 12, label: "Packages" },
       { value: 4, label: "Domain golems" },
-      { value: 55, label: "Skills" },
-      { value: 261, suffix: "+", label: "PRs merged" },
+      { value: 47, label: "Skills" },
+      { value: 317, suffix: "+", label: "PRs merged" },
     ],
     features: [
       {


### PR DESCRIPTION
## Summary
- BrainLayer chunks: 312K -> 321K (from source DB)
- Python tests: 846 -> 1030 (from brainlayer PR #90)
- Skills: 45 -> 47, eval coverage adjusted to 74%
- VoiceLayer tests: 236 -> 308
- MCP tools: 7 -> 8 (added `tags` tool)
- Golems packages: 11 -> 12, PRs merged: 261+ -> 317+

## Test plan
- [x] All stats verified from source commands/repos
- [x] Pre-commit vitest passed (10/10 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)