### PR TITLE
fix: update stale stats — 46 skills, 224K chunks, 9 MCP tools

### DIFF
--- a/app/(golems)/golems/lib/golems-stats.json
+++ b/app/(golems)/golems/lib/golems-stats.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-03-18T00:00:00Z",
+  "generatedAt": "2026-03-19T00:00:00Z",
   "skills": {
-    "count": 47,
-    "withSkillMd": 47,
+    "count": 46,
+    "withSkillMd": 46,
     "withEvals": 35,
-    "evalCoverage": "74%",
+    "evalCoverage": "76%",
     "adapterLayer": "AI-agnostic (Claude, Cursor, Gemini, Codex, Kiro)"
   },
   "packages": {
@@ -19,10 +19,10 @@
     "files": 78
   },
   "brainlayer": {
-    "chunks": 321297,
-    "chunksDisplay": "321K+",
-    "mcpTools": 8,
-    "pythonTests": 1030,
+    "chunks": 223546,
+    "chunksDisplay": "224K",
+    "mcpTools": 9,
+    "pythonTests": 923,
     "swiftTests": 28,
     "daemon": "BrainBar (209KB native binary)"
   },


### PR DESCRIPTION
## Summary
- Skills: 47→46 (reconciled with skills-manifest.json after audit)
- BrainLayer chunks: 321K→224K (post-dedup cleanup)
- BrainLayer MCP tools: 8→9 (brain_tags added)
- Python tests: 1030→923 (test suite refactored)

## Test plan
- [x] 10/10 vitest tests pass
- [ ] Visual check on Golems dashboard page

🤖 Generated with [Claude Code](https://claude.com/claude-code)