### PR TITLE
docs: add /video-extract skill to docsite

### DIFF
--- a/content/golems/skills.md
+++ b/content/golems/skills.md
@@ -45,6 +45,7 @@ Skills are Claude Code plugins that provide specialized capabilities. They're st
 | Content | `/content` | Multi-platform content creation and publishing |
 | Nightly Docs Update | `/nightly-docs-update` | Automated documentation updates |
 | YouTube Pipeline | `/youtube-pipeline` | YouTube content processing pipeline |
+| Video Extract | `/video-extract` | Extract gems from YouTube or process QA recordings — two workflows, one entry point |
 
 ### Research & Context
 

--- a/content/golems/video-extract.md
+++ b/content/golems/video-extract.md
@@ -1,0 +1,126 @@
+---
+title: "Video Extract"
+description: "Extract structured knowledge gems from YouTube videos and process QA screen recordings — two workflows, one entry point."
+---
+
+# Video Extract
+
+> Two pipelines, one command. YouTube URLs get **gem extraction** (insights, opinions, advice). Screen recordings get **QA processing** (bugs, issues, findings).
+
+## How It Works
+
+```mermaid
+flowchart TD
+    INPUT["Video Input"] --> DETECT{"URL or File?"}
+
+    DETECT -->|"YouTube URL"| GEMS["Gems Workflow"]
+    DETECT -->|"Local .mov/.mp4"| QA["QA Workflow"]
+
+    GEMS --> YTDLP["yt-dlp download"]
+    YTDLP --> WHISPER["whisper-cli transcription"]
+    WHISPER --> HOTSPOT["LLM keyword hotspot detection"]
+    HOTSPOT --> FRAMES["Frame extraction at gem timestamps"]
+    FRAMES --> VISION["Claude Vision reads frames"]
+    VISION --> DIGEST["brain_digest (full content)"]
+    DIGEST --> STORE["brain_store (structured gems)"]
+    STORE --> REPORT["Report gems to user"]
+
+    QA --> QAVIDEO["/qa-video stalker pipeline"]
+    QAVIDEO --> FINDINGS["Structured QA findings"]
+    FINDINGS --> HANDOFF["Agent handoff (optional)"]
+```
+
+## Gems Workflow (YouTube)
+
+The gems pipeline extracts reusable knowledge from YouTube videos — the kind of insights you'd bookmark, screenshot, or reference later.
+
+### Pipeline
+
+1. **Download** — `yt-dlp` extracts audio + metadata from the YouTube URL
+2. **Transcribe** — `whisper-cli` produces timestamped SRT + plain text
+3. **Detect hotspots** — LLM reads the transcript and identifies gem moments
+4. **Extract frames** — `ffmpeg` captures video frames at each gem timestamp
+5. **Vision analysis** — Claude reads frames for slides, code, diagrams
+6. **Store** — `brain_digest` + `brain_store` persist everything to BrainLayer
+7. **Report** — Structured gems with categories, quotes, and relevance
+
+### Gem Categories
+
+| Category | What It Captures |
+|----------|-----------------|
+| 💡 Insight | Non-obvious technical or conceptual shift |
+| 🔥 Opinion | Strong take, contrarian view |
+| ✅ Advice | Concrete, actionable recommendation |
+| 🔧 Tool | Specific technology mention with evaluation |
+| 🏗️ Architecture | System design pattern or structural decision |
+| ⚔️ War Story | Real production experience or post-mortem |
+| 💬 Quotable | Memorable phrasing, tweetable insight |
+
+### Example Output
+
+```
+## 🎬 T3 Code + Claude Subscriptions — Theo
+Duration: 10:12 | Gems: 7 | Stored: ✅
+
+1. 🔥 Opinion @ 3:24 — "Anthropic is massively subsidizing
+   the amount of inference... $5,000 in compute for $200"
+   → Reveals competitive moat strategy
+
+2. 🏗️ Architecture @ 6:15 — "We're using the CLIs...
+   we had to unbake a cake to reassemble it"
+   → Event system abstraction for multi-harness support
+
+3. ✅ Advice @ 8:42 — "5.4 is the best model for coding...
+   switch to Claude for UI pass, quick tidy ups"
+   → Multi-model workflow strategy
+```
+
+## QA Workflow (Screen Recordings)
+
+Delegates to the `/qa-video` stalker pipeline for screen recordings with narration:
+
+1. **Audio extraction** — `ffmpeg` extracts audio from the recording
+2. **Transcription** — `whisper-cli` converts narration to timestamped text
+3. **Hotspot detection** — LLM identifies bug reports, UX issues, feature requests
+4. **Frame extraction** — Frames at hotspot timestamps + 30-second intervals
+5. **Vision correlation** — Matches what was said with what's on screen
+6. **Findings document** — Structured by severity (Critical → Minor → Enhancement)
+7. **Agent handoff** — Sends findings to implementing agent via cmux
+
+## Routing Logic
+
+| Input | Routes To | Override |
+|-------|-----------|---------|
+| YouTube URL | Gems | Say "QA" to override |
+| Local `.mov`/`.mp4` | QA | Say "gems" to override |
+| "extract gems from..." | Gems | Regardless of source |
+| "process QA recording" | QA | Regardless of source |
+
+## Prerequisites
+
+| Tool | Purpose | Install |
+|------|---------|---------|
+| yt-dlp | YouTube download | `pip3 install yt-dlp` |
+| ffmpeg | Audio/frame extraction | `brew install ffmpeg` |
+| whisper-cli | Speech-to-text | `brew install whisper-cpp` |
+| whisper model | Transcription model | `whisper-cli --download-model small` |
+
+## BrainLayer Integration
+
+Both workflows store results in BrainLayer. Gems get `brain_digest` (full content indexing) + `brain_store` (curated gems with tags). QA findings get `brain_store` with severity counts and project tags.
+
+If BrainLayer is unavailable, the skill **loudly flags** the failure and saves a local fallback file — it never silently skips storage.
+
+## Eval Coverage
+
+7 eval cases covering:
+- URL routing (YouTube → gems, local → QA)
+- Gem quality from real transcript (Theo fixture, 8 assertions)
+- BrainLayer unavailability flagging
+- Gem-mode override for local files
+- With-skill vs without-skill comparison (10 assertions)
+- Ambiguous input clarification
+
+## Source
+
+[`skills/golem-powers/video-extract/`](https://github.com/EtanHey/golems/tree/master/skills/golem-powers/video-extract)


### PR DESCRIPTION
## Summary
- Add full docsite page for `/video-extract` skill with mermaid pipeline diagram, gem categories table, and QA workflow overview
- Update `skills.md` to include `/video-extract` in the Content skills table

## Context
Created by skill-creator agent as part of the overnight maintenance + skill sprint collab. The /video-extract skill extracts structured knowledge from YouTube videos (gems workflow) and processes QA screen recordings (QA workflow).

## Test plan
- [x] 10/10 vitest tests pass
- [ ] Verify mermaid diagram renders correctly on the docsite
- [ ] Verify skills.md table row is properly formatted

⚠️ **DO NOT MERGE** — left open per Etan's overnight quality gate. Review in the morning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)