### PR TITLE
fix: portfolio polish — architecture pages, stale README, Supabase data

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ export async function GET() {
 ### Server Actions
 
 ```typescript
-// app/(portfolio)/contact/actions.ts
+// Simplified from app/(portfolio)/contact/actions.ts
 'use server';
 
 import { Resend } from 'resend';

--- a/README.md
+++ b/README.md
@@ -407,33 +407,25 @@ export async function GET() {
 }
 ```
 
-### Form Handling
+### Server Actions
 
 ```typescript
-'use client';
+// app/(portfolio)/contact/actions.ts
+'use server';
 
-import { useForm } from 'react-hook-form';
-import { z } from 'zod';
+import { Resend } from 'resend';
 
-const schema = z.object({
-  email: z.string().email(),
-  message: z.string().min(10),
-});
+export async function submitContactForm(data: ContactFormData) {
+  const resend = new Resend(process.env.RESEND_API_KEY);
 
-export default function ContactForm() {
-  const { register, handleSubmit, formState: { errors } } = useForm({
-    resolver: zodResolver(schema),
+  await resend.emails.send({
+    from: 'Portfolio <noreply@etanheyman.com>',
+    to: process.env.CONTACT_EMAIL!,
+    subject: `Contact from ${data.fullName}`,
+    react: EmailTemplate(data),
   });
 
-  const onSubmit = async (data) => {
-    // Handle submission
-  };
-
-  return (
-    <form onSubmit={handleSubmit(onSubmit)}>
-      {/* form fields */}
-    </form>
-  );
+  return { success: true };
 }
 ```
 

--- a/app/(portfolio)/projects/[slug]/architecture-config.ts
+++ b/app/(portfolio)/projects/[slug]/architecture-config.ts
@@ -115,7 +115,7 @@ return sorted(fused, reverse=True)[:n]`,
     {
       title: "MCP Integration",
       description:
-        "11 MCP tools expose BrainLayer's full capability to any Claude Code session. 3 core memory tools handle search, persistence, and recall. 8 knowledge graph and lifecycle tools add entity extraction, digestion with 3 modes, real-time pubsub, and database stats. Started at 14 specialized tools, refined to 11 that cover every use case. BrainBar daemon provides MCP over Unix socket for always-on access.",
+        "10 MCP tools expose BrainLayer's full capability to any Claude Code session. 3 core memory tools handle search, persistence, and recall. 7 knowledge graph and lifecycle tools add entity extraction, digestion with 3 modes, and real-time pubsub. Started at 14 specialized tools, refined to 10 that cover every use case. BrainBar daemon provides MCP over Unix socket for always-on access.",
       toolList: [
         {
           name: "brain_search",
@@ -160,11 +160,6 @@ return sorted(fused, reverse=True)[:n]`,
           name: "brain_subscribe / brain_unsubscribe",
           description:
             "Pubsub for real-time memory update notifications across sessions",
-        },
-        {
-          name: "brain_stats",
-          description:
-            "Database statistics, chunk counts, enrichment progress, and health metrics",
         },
       ],
     },

--- a/app/(portfolio)/projects/[slug]/architecture-config.ts
+++ b/app/(portfolio)/projects/[slug]/architecture-config.ts
@@ -255,19 +255,19 @@ try {
     {
       title: "MCP Tool Layers",
       description:
-        "20 tools organized into three layers. Layer 1: 10 core surface tools for terminal pane control (list, split, read, send, rename, status, progress, close, browser). Layer 2: 8 agent lifecycle tools (spawn, stop, send_to, read_output, wait_for, list, get_state, set_progress). Layer 3: 2 V2 facade tools (interact + kill) that consolidate all agent operations into a clean, flat API.",
+        "21 tools organized into three layers. Layer 1: 11 core surface tools for terminal pane control (list, split, read, send, rename, status, progress, notify, close, browser). Layer 2: 8 agent lifecycle tools (spawn, stop, send_to, read_output, wait_for, wait_for_all, list, get_state). Layer 3: 2 V2 facade tools (interact + kill) that consolidate all agent operations into a clean, flat API.",
       diagramNodes: [
         {
           icon: "Terminal",
           title: "Surface Layer",
-          subtitle: "10 core tools",
-          children: ["list", "split", "read", "send", "browser"],
+          subtitle: "11 core tools",
+          children: ["list", "split", "read", "send", "notify", "browser"],
         },
         {
           icon: "Bot",
           title: "Agent Layer",
           subtitle: "8 lifecycle tools",
-          children: ["spawn", "stop", "send_to", "wait_for"],
+          children: ["spawn", "stop", "send_to", "wait_for_all"],
         },
         {
           icon: "Zap",
@@ -326,7 +326,7 @@ socket.write(JSON.stringify({
     {
       title: "Security & Quality Guards",
       description:
-        "Repository names are sanitized before shell execution — only alphanumeric characters, hyphens, underscores, and dots pass through. Agent IDs include random suffixes to prevent collision when spawning multiple agents for the same repo. All 20 tools validate input via Zod schemas. Mode enforcement: manual mode makes all mutating tools read-only. Agent quality tracking (unknown → verified → suspect → degraded) lets orchestrators filter unreliable output.",
+        "Repository names are sanitized before shell execution — only alphanumeric characters, hyphens, underscores, and dots pass through. Agent IDs include random suffixes to prevent collision when spawning multiple agents for the same repo. All 21 tools validate input via Zod schemas. Mode enforcement: manual mode makes all mutating tools read-only. Agent quality tracking (unknown → verified → suspect → degraded) lets orchestrators filter unreliable output.",
       comparisonTable: {
         headers: ["Guard", "Mechanism", "Why"],
         rows: [
@@ -334,7 +334,7 @@ socket.write(JSON.stringify({
           ["ID collision", "Random suffix", "Safe parallel spawns"],
           [
             "Input validation",
-            "Zod schemas on all 20 tools",
+            "Zod schemas on all 21 tools",
             "Type-safe at boundary",
           ],
           ["Mode enforcement", "Manual = read-only", "Safe observation mode"],
@@ -408,14 +408,14 @@ WHERE instr(LOWER(chats.name), LOWER(?)) > 0
         {
           icon: "Wrench",
           title: "Python MCP",
-          subtitle: "13 tools",
+          subtitle: "12 tools",
         },
       ],
     },
     {
       title: "MCP Tool Organization",
       description:
-        "13 tools split into query (9) and mutation (4) categories. Query tools cover every read pattern: search contacts by name or phone, list messages with filters (chat, sender, date range, content), get chat metadata, fetch message context around a specific message, and download media (images, videos, audio). Mutation tools handle sending: text messages, files with captions, and voice messages with automatic Opus/OGG conversion via FFmpeg.",
+        "12 tools split into query (9) and mutation (3) categories. Query tools cover every read pattern: search contacts by name or phone, list messages with filters (chat, sender, date range, content), get chat metadata, fetch message context around a specific message, and download media (images, videos, audio). Mutation tools handle sending: text messages, files with captions, and voice messages with automatic Opus/OGG conversion via FFmpeg.",
       toolList: [
         {
           name: "search_contacts",

--- a/app/(portfolio)/projects/[slug]/architecture-config.ts
+++ b/app/(portfolio)/projects/[slug]/architecture-config.ts
@@ -251,6 +251,224 @@ try {
     },
   ],
 
+  cmuxlayer: [
+    {
+      title: "MCP Tool Layers",
+      description:
+        "20 tools organized into three layers. Layer 1: 10 core surface tools for terminal pane control (list, split, read, send, rename, status, progress, close, browser). Layer 2: 8 agent lifecycle tools (spawn, stop, send_to, read_output, wait_for, list, get_state, set_progress). Layer 3: 2 V2 facade tools (interact + kill) that consolidate all agent operations into a clean, flat API.",
+      diagramNodes: [
+        {
+          icon: "Terminal",
+          title: "Surface Layer",
+          subtitle: "10 core tools",
+          children: ["list", "split", "read", "send", "browser"],
+        },
+        {
+          icon: "Bot",
+          title: "Agent Layer",
+          subtitle: "8 lifecycle tools",
+          children: ["spawn", "stop", "send_to", "wait_for"],
+        },
+        {
+          icon: "Zap",
+          title: "V2 Facade",
+          subtitle: "interact + kill",
+        },
+      ],
+    },
+    {
+      title: "Agent State Machine",
+      description:
+        "Each spawned agent transitions through a deterministic state machine: spawning → booting → ready → working → done. Boot detection uses screen content polling to determine when the CLI has finished loading. State transitions are event-driven — wait_for blocks until the target state is reached. Stale agents are detected via PID liveness checks.",
+      diagramNodes: [
+        { icon: "Loader", title: "Spawning", subtitle: "tmux pane created" },
+        { icon: "Clock", title: "Booting", subtitle: "CLI loading" },
+        { icon: "CheckCircle", title: "Ready", subtitle: "Boot detected" },
+        { icon: "Wrench", title: "Working", subtitle: "Prompt sent" },
+        { icon: "Check", title: "Done", subtitle: "Output extracted" },
+      ],
+      callout: {
+        title: "Why state machines?",
+        text: "Without lifecycle tracking, orchestrating multiple agents is guesswork. The state machine lets OrcClaude spawn 5 agents, wait_for each to reach 'ready', then send prompts — all with deterministic ordering.",
+      },
+    },
+    {
+      title: "cmux Socket Protocol",
+      description:
+        "CmuxLayer communicates with cmux via a Unix domain socket, achieving 1,423x speedup over CLI subprocess spawning. Every tool call serializes to a JSON command, sends it through the socket, and receives a typed response. The socket path is auto-discovered from the CMUX_SOCKET environment variable or defaults to the standard cmux socket location.",
+      codeExample: {
+        language: "typescript",
+        code: `// Socket command flow
+const socket = net.connect(CMUX_SOCKET);
+socket.write(JSON.stringify({
+  type: "new_split",
+  direction: "horizontal",
+  command: "claude --dangerously-skip-permissions"
+}));
+
+// Response: { id: "surface-42", ok: true }
+// 1,423x faster than: child_process.exec("cmux split ...")`,
+        caption: "Native MCP over Unix socket — no CLI subprocess overhead",
+      },
+    },
+    {
+      title: "Browser Surface Integration",
+      description:
+        "The browser_surface tool opens Playwright-controlled browser instances as cmux panes. A single tool with 8 action types: open (launch browser), navigate (go to URL), snapshot (capture visible state), click (element interaction), type (text input), eval (run JavaScript), wait (element/timeout), and url (get current URL). Enables visual verification alongside terminal agents in the same orchestration flow.",
+      diagramNodes: [
+        { icon: "Globe", title: "Open", subtitle: "Launch Playwright" },
+        { icon: "Navigation", title: "Navigate", subtitle: "Go to URL" },
+        { icon: "Camera", title: "Snapshot", subtitle: "Capture state" },
+        { icon: "MousePointer", title: "Interact", subtitle: "Click + type" },
+        { icon: "Code", title: "Evaluate", subtitle: "Run JavaScript" },
+      ],
+    },
+    {
+      title: "Security & Quality Guards",
+      description:
+        "Repository names are sanitized before shell execution — only alphanumeric characters, hyphens, underscores, and dots pass through. Agent IDs include random suffixes to prevent collision when spawning multiple agents for the same repo. All 20 tools validate input via Zod schemas. Mode enforcement: manual mode makes all mutating tools read-only. Agent quality tracking (unknown → verified → suspect → degraded) lets orchestrators filter unreliable output.",
+      comparisonTable: {
+        headers: ["Guard", "Mechanism", "Why"],
+        rows: [
+          ["Repo sanitization", "Regex allowlist", "Prevents shell injection"],
+          ["ID collision", "Random suffix", "Safe parallel spawns"],
+          [
+            "Input validation",
+            "Zod schemas on all 20 tools",
+            "Type-safe at boundary",
+          ],
+          ["Mode enforcement", "Manual = read-only", "Safe observation mode"],
+          ["Spawn depth", "MAX_SPAWN_DEPTH=2", "Prevents recursion bombs"],
+          ["Child cap", "MAX_CHILDREN_PER_AGENT=10", "Resource limits"],
+        ],
+      },
+    },
+  ],
+
+  "whatsapp-mcp": [
+    {
+      title: "Go Bridge Architecture",
+      description:
+        "The Go bridge uses whatsmeow to authenticate with WhatsApp Web via QR code scan. Messages are stored in a local SQLite database. A REST API on port 8741 (personal) or 8742 (business) exposes send operations. The bridge runs as a long-lived process that maintains the WhatsApp Web session.",
+      diagramNodes: [
+        { icon: "Smartphone", title: "WhatsApp Web", subtitle: "QR auth" },
+        { icon: "Code", title: "whatsmeow", subtitle: "Go client library" },
+        { icon: "Database", title: "SQLite", subtitle: "Message store" },
+        { icon: "Server", title: "REST API", subtitle: "Port 8741/8742" },
+      ],
+    },
+    {
+      title: "Unicode Search Fix",
+      description:
+        "SQLite's built-in LOWER() function only handles ASCII characters (A-Z → a-z). For Hebrew, Arabic, emoji, and CJK text, LOWER() is a no-op — the text passes through unchanged. The upstream repo's LOWER(column) LIKE LOWER(?) pattern silently fails for non-Latin scripts. Our fork replaces this with instr()-based matching: a dual check that handles both case-insensitive Latin and direct Unicode byte-level matching.",
+      codeExample: {
+        language: "python",
+        code: `# Upstream (broken for Hebrew/Arabic/CJK):
+WHERE LOWER(chats.name) LIKE LOWER(?)
+# → LOWER("שלום") returns "שלום" unchanged
+# → LIKE "%שלום%" may fail on substring match
+
+# Our fork (works for all Unicode):
+WHERE instr(LOWER(chats.name), LOWER(?)) > 0
+   OR instr(chats.name, ?) > 0
+# → instr() does byte-level substring matching
+# → Dual check: case-insensitive Latin + direct Unicode`,
+        caption: "Applied to list_chats, list_messages, and search_contacts",
+      },
+      callout: {
+        title: "Why not ICU extension?",
+        text: "SQLite can load the ICU extension for proper Unicode collation, but it requires a C library dependency and isn't available in all environments. instr() is built-in, zero-dependency, and works everywhere SQLite runs.",
+      },
+    },
+    {
+      title: "Dual-Bridge Auto-Detection",
+      description:
+        "The Python MCP server checks for a business bridge database at whatsapp-bridge-business/store/messages.db. If it exists, it connects to the business bridge. Otherwise it falls back to the personal bridge at whatsapp-bridge/store/messages.db. Environment variables WHATSAPP_DB_PATH and WHATSAPP_API_URL override auto-detection for custom setups.",
+      diagramNodes: [
+        {
+          icon: "Smartphone",
+          title: "Personal Bridge",
+          subtitle: "Port 8741",
+        },
+        {
+          icon: "Briefcase",
+          title: "Business Bridge",
+          subtitle: "Port 8742",
+        },
+        {
+          icon: "GitBranch",
+          title: "Auto-Detect",
+          subtitle: "Check file existence",
+        },
+        {
+          icon: "Database",
+          title: "SQLite DB",
+          subtitle: "Shared schema",
+        },
+        {
+          icon: "Wrench",
+          title: "Python MCP",
+          subtitle: "13 tools",
+        },
+      ],
+    },
+    {
+      title: "MCP Tool Organization",
+      description:
+        "13 tools split into query (9) and mutation (4) categories. Query tools cover every read pattern: search contacts by name or phone, list messages with filters (chat, sender, date range, content), get chat metadata, fetch message context around a specific message, and download media (images, videos, audio). Mutation tools handle sending: text messages, files with captions, and voice messages with automatic Opus/OGG conversion via FFmpeg.",
+      toolList: [
+        {
+          name: "search_contacts",
+          description: "Unicode-safe name + phone search",
+        },
+        {
+          name: "list_messages",
+          description: "Filter by chat, sender, date, content",
+        },
+        {
+          name: "list_chats",
+          description: "All chats with optional last-message preview",
+        },
+        { name: "get_chat", description: "Chat metadata by JID" },
+        {
+          name: "get_direct_chat_by_contact",
+          description: "Find DM chat for a contact",
+        },
+        {
+          name: "get_contact_chats",
+          description: "All chats involving a contact",
+        },
+        {
+          name: "get_last_interaction",
+          description: "Most recent message with a contact",
+        },
+        {
+          name: "get_message_context",
+          description: "Messages around a specific message ID",
+        },
+        {
+          name: "download_media",
+          description: "Images, videos, audio from messages",
+        },
+        { name: "send_message", description: "Text message to a JID" },
+        { name: "send_file", description: "File with optional caption" },
+        {
+          name: "send_audio_message",
+          description: "Voice message with FFmpeg Opus conversion",
+        },
+      ],
+    },
+    {
+      title: "Self-Chat Safety",
+      description:
+        "When WHATSAPP_OWNER_JID is set, all send operations (send_message, send_file, send_audio_message) are restricted to the owner's JID — effectively a 'Saved Messages' mode. Read operations remain unrestricted, so Claude can search and reference any conversation. Phone numbers are normalized: leading '+' stripped, whitespace removed, @s.whatsapp.net appended.",
+      callout: {
+        title: "Why self-chat?",
+        text: "Letting an LLM send messages to arbitrary contacts is dangerous. Self-chat mode lets Claude use WhatsApp as a note-taking and reference tool without risk of accidentally messaging people. Read everything, send only to yourself.",
+      },
+    },
+  ],
+
   golems: [
     {
       title: "Monorepo Structure",

--- a/app/(portfolio)/projects/[slug]/architecture-config.ts
+++ b/app/(portfolio)/projects/[slug]/architecture-config.ts
@@ -255,7 +255,7 @@ try {
     {
       title: "MCP Tool Layers",
       description:
-        "21 tools organized into three layers. Layer 1: 11 core surface tools for terminal pane control (list, split, read, send, rename, status, progress, notify, close, browser). Layer 2: 8 agent lifecycle tools (spawn, stop, send_to, read_output, wait_for, wait_for_all, list, get_state). Layer 3: 2 V2 facade tools (interact + kill) that consolidate all agent operations into a clean, flat API.",
+        "21 tools organized into three layers. Layer 1: 11 core surface tools for terminal pane control (list, split, read, send, send_key, rename, status, progress, notify, close, browser). Layer 2: 8 agent lifecycle tools (spawn, stop, send_to, read_output, wait_for, wait_for_all, list, get_state). Layer 3: 2 V2 facade tools (interact + kill) that consolidate all agent operations into a clean, flat API.",
       diagramNodes: [
         {
           icon: "Terminal",

--- a/app/(portfolio)/projects/[slug]/features-config.ts
+++ b/app/(portfolio)/projects/[slug]/features-config.ts
@@ -226,7 +226,7 @@ const featuresData: Record<string, FeatureSection[]> = {
   cmuxlayer: [
     {
       iconName: "Terminal",
-      title: "10 Core Surface Tools",
+      title: "11 Core Surface Tools",
       tagline: "Full terminal pane control through MCP",
       description:
         "list_surfaces, new_split, send_input, send_key, read_screen, rename_tab, set_status, set_progress, close_surface, and browser_surface. These wrap the cmux CLI socket into typed, validated tools. browser_surface alone handles 8 actions: open, navigate, snapshot, click, type, eval, wait, and url.",
@@ -311,7 +311,7 @@ kill({ target: "all" })          // everything`,
         "Repo name sanitization — blocks shell metacharacters",
         "Random suffix on agent IDs — no collisions",
         "Mode policy — manual mode = read-only surface tools",
-        "Input validation on all 20 tools via Zod schemas",
+        "Input validation on all 21 tools via Zod schemas",
       ],
     },
     {

--- a/app/(portfolio)/projects/[slug]/getting-started-config.ts
+++ b/app/(portfolio)/projects/[slug]/getting-started-config.ts
@@ -170,7 +170,7 @@ const gettingStartedData: Record<string, GettingStartedStep[]> = {
       step: 5,
       title: "Run tests",
       description:
-        "259 test assertions across 15 test files verify tool registration, agent lifecycle, V2 semantics, hierarchy, and quality tracking.",
+        "278 test assertions across 15 test files verify tool registration, agent lifecycle, V2 semantics, hierarchy, and quality tracking.",
       command: "npm test",
       note: "Uses Vitest. All tests run locally with mocked cmux client.",
     },

--- a/app/(portfolio)/projects/[slug]/page.tsx
+++ b/app/(portfolio)/projects/[slug]/page.tsx
@@ -29,7 +29,7 @@ import { highlightCode } from "@/lib/highlight";
 const PROJECT_DESCRIPTIONS: Record<string, string> = {
   brainlayer: `Persistent memory layer for AI coding assistants. ${golemsStats.brainlayer.chunksDisplay} deduplicated chunks, ${golemsStats.brainlayer.mcpTools} MCP tools (search, store, recall + knowledge graph), 119 KG entities, hybrid semantic search with sqlite-vec. Faceted enrichment v2 with Gemini 2.5 Flash.`,
   voicelayer:
-    "Bi-directional voice I/O layer for AI assistants. VoiceBar daemon with LaunchAgent auto-start. TTS via edge-tts + Qwen3, STT via whisper.cpp + Wispr Flow (~300ms). 2 tools (voice_speak, voice_ask) with auto-mode detection. 308 tests.",
+    "Bi-directional voice I/O layer for AI assistants. VoiceBar MCP daemon with LaunchAgent auto-start. TTS via edge-tts, STT via whisper.cpp + Wispr Flow (~300ms). 2 tools (voice_speak, voice_ask) with auto-mode detection. 314 tests.",
   cmuxlayer:
     "Terminal orchestration for AI agents. 21 MCP tools across 3 layers: surface control, agent lifecycle (spawn_agent, stop_agent, send_to_agent), and V2 facade. Playwright browser surfaces. 1,423x socket speedup via native MCP.",
   "whatsapp-mcp":

--- a/app/(portfolio)/projects/[slug]/page.tsx
+++ b/app/(portfolio)/projects/[slug]/page.tsx
@@ -27,13 +27,13 @@ import { getTerminalShowcaseData } from "./terminal-showcase-config";
 import { highlightCode } from "@/lib/highlight";
 
 const PROJECT_DESCRIPTIONS: Record<string, string> = {
-  brainlayer: `Persistent memory layer for AI coding assistants. ${golemsStats.brainlayer.chunksDisplay} deduplicated chunks, 9 MCP tools (search, store, recall + knowledge graph), 119 KG entities, hybrid semantic search with sqlite-vec. Faceted enrichment v2 with Gemini 2.5 Flash.`,
+  brainlayer: `Persistent memory layer for AI coding assistants. ${golemsStats.brainlayer.chunksDisplay} deduplicated chunks, ${golemsStats.brainlayer.mcpTools} MCP tools (search, store, recall + knowledge graph), 119 KG entities, hybrid semantic search with sqlite-vec. Faceted enrichment v2 with Gemini 2.5 Flash.`,
   voicelayer:
     "Bi-directional voice I/O layer for AI assistants. VoiceBar daemon with LaunchAgent auto-start. TTS via edge-tts + Qwen3, STT via whisper.cpp + Wispr Flow (~300ms). 2 tools (voice_speak, voice_ask) with auto-mode detection. 308 tests.",
   cmuxlayer:
-    "Terminal orchestration for AI agents. 20 MCP tools across 3 layers: surface control, agent lifecycle (spawn_agent, stop_agent, send_to_agent), and V2 facade. Playwright browser surfaces. 1,423x socket speedup via native MCP.",
+    "Terminal orchestration for AI agents. 21 MCP tools across 3 layers: surface control, agent lifecycle (spawn_agent, stop_agent, send_to_agent), and V2 facade. Playwright browser surfaces. 1,423x socket speedup via native MCP.",
   "whatsapp-mcp":
-    "Hebrew-compatible WhatsApp MCP fork. Fixed Unicode search (instr() over LOWER+LIKE), dual-bridge personal+business auto-detection, self-chat safety mode. 13 MCP tools for reading and sending messages.",
+    "Hebrew-compatible WhatsApp MCP fork. Fixed Unicode search (instr() over LOWER+LIKE), dual-bridge personal+business auto-detection, self-chat safety mode. 12 MCP tools for reading and sending messages.",
   golems: `Autonomous AI agent ecosystem. ${golemsStats.packages.count} packages, ${golemsStats.agents.count} domain agents, ${golemsStats.skills.count} skills, multi-LLM routing, Night Shift autonomous coding at 4am.`,
 };
 

--- a/app/(portfolio)/projects/[slug]/project-showcase-config.ts
+++ b/app/(portfolio)/projects/[slug]/project-showcase-config.ts
@@ -215,7 +215,7 @@ const configs: Record<string, ProjectShowcaseConfig> = {
         title: "CLI Command",
         subtitle: "spawn / interact / kill",
       },
-      { icon: "Wrench", title: "MCP Server", subtitle: "20 typed tools" },
+      { icon: "Wrench", title: "MCP Server", subtitle: "21 typed tools" },
       { icon: "Monitor", title: "cmux Socket", subtitle: "Terminal control" },
       {
         icon: "Bot",
@@ -289,7 +289,7 @@ const configs: Record<string, ProjectShowcaseConfig> = {
       {
         icon: "Wrench",
         title: "Python MCP",
-        subtitle: "13 tools, instr() search",
+        subtitle: "12 tools, instr() search",
       },
       { icon: "Bot", title: "AI Agent", subtitle: "Claude / Cursor" },
     ],

--- a/app/(portfolio)/projects/[slug]/project-showcase-config.ts
+++ b/app/(portfolio)/projects/[slug]/project-showcase-config.ts
@@ -168,7 +168,7 @@ const configs: Record<string, ProjectShowcaseConfig> = {
     stats: [
       { value: 21, label: "MCP tools" },
       { value: 5, label: "Supported CLIs" },
-      { value: 259, label: "Test assertions" },
+      { value: 278, label: "Test assertions" },
       { value: 3, label: "API layers" },
     ],
     features: [

--- a/app/(portfolio)/projects/[slug]/project-showcase-config.ts
+++ b/app/(portfolio)/projects/[slug]/project-showcase-config.ts
@@ -112,7 +112,7 @@ const configs: Record<string, ProjectShowcaseConfig> = {
       { value: 2, label: "MCP tools" },
       { value: 2, label: "STT backends" },
       { value: 300, suffix: "ms", prefix: "~", label: "STT latency" },
-      { value: 308, label: "Tests passing" },
+      { value: 314, label: "Tests passing" },
     ],
     features: [
       {

--- a/app/(portfolio)/projects/[slug]/project-showcase-config.ts
+++ b/app/(portfolio)/projects/[slug]/project-showcase-config.ts
@@ -166,7 +166,7 @@ const configs: Record<string, ProjectShowcaseConfig> = {
     tagline: "@golems/cmux-mcp",
     isMiniSite: true,
     stats: [
-      { value: 20, label: "MCP tools" },
+      { value: 21, label: "MCP tools" },
       { value: 5, label: "Supported CLIs" },
       { value: 259, label: "Test assertions" },
       { value: 3, label: "API layers" },
@@ -174,9 +174,9 @@ const configs: Record<string, ProjectShowcaseConfig> = {
     features: [
       {
         iconName: "Terminal",
-        title: "20 MCP Tools, 3 Layers",
+        title: "21 MCP Tools, 3 Layers",
         description:
-          "10 core surface tools (split, read, send, rename), 8 agent lifecycle tools (spawn_agent, stop_agent, send_to_agent, wait_for), and 2 V2 facade tools (interact + kill).",
+          "11 core surface tools (split, read, send, send_key, notify, rename), 8 agent lifecycle tools (spawn_agent, stop_agent, send_to_agent, wait_for), and 2 V2 facade tools (interact + kill).",
       },
       {
         iconName: "Bot",
@@ -235,7 +235,7 @@ const configs: Record<string, ProjectShowcaseConfig> = {
     tagline: "Fork of lharries/whatsapp-mcp",
     isMiniSite: true,
     stats: [
-      { value: 13, label: "MCP tools" },
+      { value: 12, label: "MCP tools" },
       { value: 2, label: "Bridge support" },
       { value: 3, label: "Unicode search fixes" },
       { value: 5.4, suffix: "K", label: "Upstream stars" },
@@ -261,9 +261,9 @@ const configs: Record<string, ProjectShowcaseConfig> = {
       },
       {
         iconName: "MessageSquare",
-        title: "13 MCP Tools",
+        title: "12 MCP Tools",
         description:
-          "9 read tools (search contacts, list messages, get chat, download media) + 4 write tools (send message, send file, send audio with auto Opus conversion).",
+          "9 read tools (search contacts, list messages, get chat, download media) + 3 write tools (send message, send file, send audio with auto Opus conversion).",
       },
     ],
     installTabs: [


### PR DESCRIPTION
## Summary
- **Architecture pages fix**: cmuxlayer and whatsapp-mcp `/architecture` tabs were returning 404 (no data in `architecture-config.ts`). Added 5 architecture sections each with diagrams, code examples, comparison tables, and callouts.
- **README stale code fix**: Replaced `react-hook-form`/`zod` code example with Server Actions pattern (Resend email) — neither dependency exists in package.json.
- **Supabase data fixes** (not in code diff — applied via SQL):
  - Added 5 journey steps for cmuxlayer (extraction origin → V2 facade)
  - Added 5 journey steps for whatsapp-mcp (problem → upstream PR)
  - Fixed casona-diez-diez description ("Hostel" → full description)
  - Fixed real-estate-platform newline in short_description

## Test plan
- [x] `next build` passes — all architecture pages render for all 5 mini-site projects
- [x] 10/10 tests pass (`vitest run`)
- [ ] Visual check: `/projects/cmuxlayer/architecture` renders content (not 404)
- [ ] Visual check: `/projects/whatsapp-mcp/architecture` renders content (not 404)
- [ ] README no longer references react-hook-form or zod

🤖 Generated with [Claude Code](https://claude.com/claude-code)