### PR TITLE
feat: reframe portfolio — AI infrastructure engineer positioning

### DIFF
--- a/app/(portfolio)/page.tsx
+++ b/app/(portfolio)/page.tsx
@@ -36,7 +36,7 @@ export default async function Home() {
 
             {/* Tagline */}
             <p className="font-[Nutmeg] text-[26px] leading-none font-light text-white sm:text-[30px] md:text-[32px] lg:text-[36px] xl:text-[40px]">
-              I'll develop anything, anywhere.
+              Building infrastructure for AI agents.
             </p>
 
             {/* CTA Buttons */}

--- a/app/components/GolemsEcosystem.tsx
+++ b/app/components/GolemsEcosystem.tsx
@@ -123,8 +123,8 @@ export default function GolemsEcosystem() {
             Golems Ecosystem
           </h2>
           <p className="mt-2 font-[Nutmeg] text-[15px] leading-[1.3] font-light text-white/60 sm:text-[17px] md:text-[18px]">
-            Open-source infrastructure layers that give AI agents memory, voice,
-            and terminal control.
+            3 open-source MCP servers. 44 tools. Persistent memory, voice I/O,
+            and multi-agent orchestration for AI coding assistants.
           </p>
         </div>
 

--- a/app/components/navigation/about/TimelineParallax.tsx
+++ b/app/components/navigation/about/TimelineParallax.tsx
@@ -23,9 +23,10 @@ const BRAND_LIGHT = "#3B9FFF";
 const timelineData = [
   {
     period: "08/2024-TODAY",
-    title: "Software Engineer • Cantaloupe AI - New Orleans, LA/Denver, CO",
+    title:
+      "AI/Full-Stack Engineer • Cantaloupe AI - New Orleans, LA/Denver, CO",
     description:
-      "Building recruitment platform from the ground up. Tech stack: React Native → Svelte → Bubble.io → Svelte → Next.js. Implemented Vapi.ai integration for automated candidate screening (reducing manual work by 80%), designed database schemas, built real-time features, created responsive dashboards, and integrated third-party services including Merge.dev ATS/HRIS systems, Google Maps APIs, Twilio messaging, and bilingual i18n support.",
+      "Built AI-powered hiring platform with Vapi.ai voice interview integration — automated candidate screening reducing manual work by 80%. Designed database schemas, built real-time features, created responsive dashboards, and integrated Merge.dev ATS/HRIS, Google Maps, Twilio messaging, and bilingual i18n. Stack evolved through React Native → Svelte → Next.js.",
   },
   {
     period: "11/2023-08/2024",
@@ -71,7 +72,8 @@ const timelineData = [
   },
   {
     period: "2013-2016",
-    title: "Art Major • Ironi Alef School of Arts and Sciences - Modi'in, Israel",
+    title:
+      "Art Major • Ironi Alef School of Arts and Sciences - Modi'in, Israel",
     description:
       "Studied visual arts and creative design, developing a strong foundation in aesthetics and visual communication that would later inform my approach to frontend development and UI/UX work.",
   },
@@ -188,9 +190,7 @@ function TimelineCard({
       {/* Entrance animation wrapper — 3D unfold on scroll */}
       <motion.div
         initial={
-          reducedMotion
-            ? { opacity: 0 }
-            : { opacity: 0, y: 30, rotateX: 6 }
+          reducedMotion ? { opacity: 0 } : { opacity: 0, y: 30, rotateX: 6 }
         }
         animate={
           isInView
@@ -298,7 +298,7 @@ function TimelineCard({
 
           {/* Description */}
           <motion.p
-            className="text-xs font-light leading-relaxed sm:text-sm"
+            className="text-xs leading-relaxed font-light sm:text-sm"
             animate={{
               color: isActive
                 ? "rgba(209, 213, 219, 1)"


### PR DESCRIPTION
## Summary
Per R63 go-to-market research — reframes portfolio for AI engineering positioning:

- **Hero tagline**: "I'll develop anything, anywhere" → "Building infrastructure for AI agents"
- **Cantaloupe AI**: Title "Software Engineer" → "AI/Full-Stack Engineer", description leads with "AI-powered hiring platform with Vapi.ai voice interview integration"
- **GolemsEcosystem subtitle**: "3 open-source MCP servers. 44 tools." — concrete numbers

## Test plan
- [x] Build passes
- [x] 10 tests pass
- [ ] Visual: hero tagline reads as AI-focused, not generic developer

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)