### PR TITLE
fix: headline → Building open-source tools for AI agents

### DIFF
--- a/app/(portfolio)/page.tsx
+++ b/app/(portfolio)/page.tsx
@@ -36,7 +36,7 @@ export default async function Home() {
 
             {/* Tagline */}
             <p className="font-[Nutmeg] text-[26px] leading-none font-light text-white sm:text-[30px] md:text-[32px] lg:text-[36px] xl:text-[40px]">
-              Building infrastructure for AI agents.
+              Building open-source tools for AI agents.
             </p>
 
             {/* CTA Buttons */}


### PR DESCRIPTION
## Summary
Phase 5 plan specifies "Building open-source tools for AI agents" — PR #86 used "infrastructure" instead. This updates to the exact planned wording, which signals the open-source contribution angle more clearly.

One-line change: `page.tsx` line 39.

## Test plan
- [x] Build passes
- [x] 10 tests pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)