### PR TITLE
feat: portfolio quality iteration — SEO, ordering, CTA, About title

### DIFF
--- a/app/(portfolio)/about/page.tsx
+++ b/app/(portfolio)/about/page.tsx
@@ -62,9 +62,7 @@ const AboutPage = () => {
           </h1>
           <div className="flex items-center gap-4">
             <LaptopIcon />
-            <h3 className="text-2xl font-light xl:text-[32px]">
-              Full Stack Engineer
-            </h3>
+            <h3 className="text-2xl font-light xl:text-[32px]">AI Engineer</h3>
           </div>
           <div className="flex items-center gap-4">
             <LocationIcon />

--- a/app/(portfolio)/layout.tsx
+++ b/app/(portfolio)/layout.tsx
@@ -41,16 +41,16 @@ const nutmeg = localFont({
 });
 
 export const metadata: Metadata = {
-  title: "Etan Heyman",
+  title: "Etan Heyman — AI Engineer",
   description:
-    "Personal website of Etan Heyman | UI/UX Design by Dor Zohar (ProductDZ)",
+    "Building open-source tools for AI agents. Creator of Golems: 3 MCP servers, 44 tools — persistent memory, voice I/O, multi-agent orchestration.",
   keywords: [
+    "AI engineer",
+    "MCP server",
+    "AI agents",
+    "open source",
     "developer",
     "portfolio",
-    "software engineer",
-    "Dor Zohar",
-    "ProductDZ",
-    "UI/UX design",
   ],
   authors: [
     { name: "Etan Heyman" },
@@ -81,8 +81,8 @@ export const metadata: Metadata = {
     url: "https://etanheyman.com",
     title: "Etan Heyman",
     description:
-      "Personal website of Etan Heyman | UI/UX Design by Dor Zohar (ProductDZ)",
-    siteName: "Etan Heyman's Portfolio | Full-Stack Developer",
+      "AI Engineer building open-source tools for AI agents. Creator of the Golems ecosystem: 3 MCP servers, 44 tools.",
+    siteName: "Etan Heyman | AI Engineer",
     images: [
       {
         url: "/favicon/web-app-manifest-512x512.png",
@@ -96,7 +96,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Etan Heyman",
     description:
-      "Personal website of Etan Heyman | UI/UX Design by Dor Zohar (ProductDZ)",
+      "AI Engineer building open-source tools for AI agents. Creator of the Golems ecosystem: 3 MCP servers, 44 tools.",
     images: ["/favicon/web-app-manifest-512x512.png"],
   },
   verification: {

--- a/app/(portfolio)/page.tsx
+++ b/app/(portfolio)/page.tsx
@@ -74,6 +74,9 @@ export default async function Home() {
         </div>
       </section>
 
+      {/* Golems Ecosystem Section — centerpiece, above projects */}
+      <GolemsEcosystem />
+
       {/* Projects Section */}
       <section
         id="projects"
@@ -102,18 +105,15 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* Golems Ecosystem Section */}
-      <GolemsEcosystem />
-
       {/* CTA Section */}
       <section className="px-[18px] pt-6 pb-12 sm:px-8 md:px-12 md:pt-8 md:pb-16 lg:px-20 lg:pt-12 lg:pb-20 xl:px-40 xl:pt-14 xl:pb-24 2xl:px-[323px]">
         <div className="mx-auto flex max-w-[354px] flex-col gap-6 sm:max-w-[500px] md:max-w-none md:flex-row md:items-center md:gap-8 lg:gap-12">
           <div className="flex flex-col gap-2 md:flex-1 md:gap-4">
             <h2 className="font-[Nutmeg] text-[26px] leading-none font-semibold text-blue-200 sm:text-[32px] md:text-[36px] lg:text-[42px] xl:text-[48px]">
-              Like what you see?
+              Let's build something.
             </h2>
             <p className="font-[Nutmeg] text-[22px] leading-none font-light text-white sm:text-[24px] md:text-[26px] lg:text-[30px] xl:text-[32px]">
-              Don't hesitate to contact me right away!
+              Looking for an AI engineer who ships production tools.
             </p>
           </div>
           <Link href="/contact" className="w-full sm:w-auto md:w-auto">


### PR DESCRIPTION
## Summary
5 rounds of iteration on portfolio positioning:

1. **SEO metadata**: `siteName` "Full-Stack Developer" → "AI Engineer", `description` mentions Golems ecosystem (44 tools, 3 MCP servers)
2. **Keywords**: "developer, portfolio, UI/UX design" → "AI engineer, MCP server, AI agents, open source"
3. **Homepage flow**: Golems Ecosystem moved ABOVE projects section — the centerpiece work appears first
4. **CTA**: "Like what you see?" → "Let's build something." / "Looking for an AI engineer who ships production tools."
5. **About page**: Job title "Full Stack Engineer" → "AI Engineer"

Page flow is now: Hero ("Building open-source tools for AI agents") → Golems Ecosystem (3 MCP servers) → Projects → CTA

## Test plan
- [x] Build passes
- [x] 10 tests pass
- [x] No "Full-Stack Developer" remaining in metadata/UI (only in historical timeline entries)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)