### PR TITLE
fix: address voiceSiteClaude audit — data corrections + copy

### DIFF
--- a/app/(golems)/golems/lib/golems-stats.json
+++ b/app/(golems)/golems/lib/golems-stats.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-03-28T00:00:00Z",
+  "generatedAt": "2026-04-02T00:00:00Z",
   "skills": {
-    "count": 55,
-    "withSkillMd": 55,
-    "withEvals": 40,
-    "evalCoverage": "73%",
+    "count": 36,
+    "withSkillMd": 36,
+    "withEvals": 34,
+    "evalCoverage": "94%",
     "adapterLayer": "AI-agnostic (Claude, Cursor, Gemini, Codex, Kiro)"
   },
   "packages": {
@@ -28,7 +28,7 @@
     "daemon": "BrainBar (209KB native binary)"
   },
   "voicelayer": {
-    "tests": 359,
+    "tests": 540,
     "daemon": "MCP daemon, dual-protocol (NDJSON + MCP Content-Length)"
   },
   "cmuxlayer": {

--- a/app/(golems)/golems/page.tsx
+++ b/app/(golems)/golems/page.tsx
@@ -65,7 +65,7 @@ const products = [
   {
     name: "VoiceLayer",
     tagline: "Voice I/O for AI agents",
-    description: `${golemsStats.voicelayer.tests} tests. Dual-protocol MCP daemon. Talk to your agents, hear them respond.`,
+    description: `${golemsStats.voicelayer.tests} tests. 11 MCP tools. Talk to your agents, hear them respond.`,
     href: "https://voicelayer.etanheyman.com",
     color: "#2dd4a8",
     icon: (
@@ -748,8 +748,7 @@ const individualInstalls = [
   {
     name: "VoiceLayer",
     command: "npm i voicelayer-mcp",
-    description:
-      "Voice I/O — speech-to-text, text-to-speech, dual-protocol MCP",
+    description: "Voice I/O — speech-to-text, text-to-speech, 11 MCP tools",
     color: "#2dd4a8",
     language: "Node.js",
   },
@@ -894,7 +893,7 @@ function BuilderProfile() {
           Built by Etan Heyman
         </h2>
         <p className="mb-8 text-center text-[#b0a89c] italic">
-          Full-stack engineer building open-source tools for AI agents.
+          AI engineer building open-source tools for AI agents.
         </p>
 
         <div className="rounded-xl border border-[#e5950020] bg-[#14120e]/90 p-6">


### PR DESCRIPTION
## Summary
Fixes 4 issues from voiceSiteClaude's audit (rated page 8/10):
1. VoiceLayer test count 359→540 in golems-stats.json
2. VoiceLayer card/install copy: "dual-protocol MCP" → "11 MCP tools"
3. Builder profile: "full-stack engineer" → "AI engineer"
4. Skill count 55→36 in golems-stats.json (36 top-level verified)
5. "Spawn→Work→Die→Remember" tagline confirmed present — no fix needed

## Test plan
- [x] `next build` passes
- [x] `vitest run` — 10/10 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Golems Redesign collab — Audit fix PR #6**