### PR TITLE
fix: cmuxlayer architecture stale numbers + logo

### DIFF
--- a/app/(portfolio)/projects/[slug]/architecture-config.ts
+++ b/app/(portfolio)/projects/[slug]/architecture-config.ts
@@ -250,18 +250,26 @@ try {
     {
       title: "MCP Tool Layers",
       description:
-        "21 tools organized into three layers. Layer 1: 11 core surface tools for terminal pane control (list, split, read, send, send_key, rename, status, progress, notify, close, browser). Layer 2: 8 agent lifecycle tools (spawn, stop, send_to, read_output, wait_for, wait_for_all, list, get_state). Layer 3: 2 V2 facade tools (interact + kill) that consolidate all agent operations into a clean, flat API.",
+        "25 tools organized into three layers. Layer 1: 13 core surface tools for terminal pane control (list, split, read, send, send_key, rename, status, progress, notify, close, browser, move, reorder, new_surface). Layer 2: 10 agent lifecycle tools (spawn, stop, send_to, read_output, wait_for, wait_for_all, list, get_state, my_agents, interact). Layer 3: 2 V2 facade tools (interact + kill) that consolidate all agent operations into a clean, flat API.",
       diagramNodes: [
         {
           icon: "Terminal",
           title: "Surface Layer",
-          subtitle: "11 core tools",
-          children: ["list", "split", "read", "send", "notify", "browser"],
+          subtitle: "13 core tools",
+          children: [
+            "list",
+            "split",
+            "read",
+            "send",
+            "notify",
+            "move",
+            "reorder",
+          ],
         },
         {
           icon: "Bot",
           title: "Agent Layer",
-          subtitle: "8 lifecycle tools",
+          subtitle: "10 lifecycle tools",
           children: ["spawn", "stop", "send_to", "wait_for_all"],
         },
         {
@@ -321,7 +329,7 @@ socket.write(JSON.stringify({
     {
       title: "Security & Quality Guards",
       description:
-        "Repository names are sanitized before shell execution — only alphanumeric characters, hyphens, underscores, and dots pass through. Agent IDs include random suffixes to prevent collision when spawning multiple agents for the same repo. All 21 tools validate input via Zod schemas. Mode enforcement: manual mode makes all mutating tools read-only. Agent quality tracking (unknown → verified → suspect → degraded) lets orchestrators filter unreliable output.",
+        "Repository names are sanitized before shell execution — only alphanumeric characters, hyphens, underscores, and dots pass through. Agent IDs include random suffixes to prevent collision when spawning multiple agents for the same repo. All 25 tools validate input via Zod schemas. Mode enforcement: manual mode makes all mutating tools read-only. Agent quality tracking (unknown → verified → suspect → degraded) lets orchestrators filter unreliable output.",
       comparisonTable: {
         headers: ["Guard", "Mechanism", "Why"],
         rows: [
@@ -329,7 +337,7 @@ socket.write(JSON.stringify({
           ["ID collision", "Random suffix", "Safe parallel spawns"],
           [
             "Input validation",
-            "Zod schemas on all 21 tools",
+            "Zod schemas on all 25 tools",
             "Type-safe at boundary",
           ],
           ["Mode enforcement", "Manual = read-only", "Safe observation mode"],

--- a/app/(portfolio)/projects/[slug]/components/FeaturesGrid.tsx
+++ b/app/(portfolio)/projects/[slug]/components/FeaturesGrid.tsx
@@ -11,6 +11,13 @@ import {
   Bot,
   Zap,
   Cloud,
+  Terminal,
+  Globe,
+  GitBranch,
+  Smartphone,
+  Shield,
+  MessageSquare,
+  Layers,
   type LucideIcon,
 } from "lucide-react";
 import type { ProjectFeature } from "../project-showcase-config";
@@ -28,6 +35,13 @@ const icons: Record<string, LucideIcon> = {
   Bot,
   Zap,
   Cloud,
+  Terminal,
+  Globe,
+  GitBranch,
+  Smartphone,
+  Shield,
+  MessageSquare,
+  Layers,
 };
 
 export function FeaturesGrid({
@@ -71,7 +85,7 @@ export function FeaturesGrid({
               <h3 className="mb-2 font-[Nutmeg] text-[17px] font-semibold text-white">
                 {feature.title}
               </h3>
-              <p className="font-[Nutmeg] text-[14px] font-light leading-relaxed text-white/55">
+              <p className="font-[Nutmeg] text-[14px] leading-relaxed font-light text-white/55">
                 {feature.description}
               </p>
             </div>

--- a/app/(portfolio)/projects/[slug]/page.tsx
+++ b/app/(portfolio)/projects/[slug]/page.tsx
@@ -151,21 +151,17 @@ export default async function ProjectPage({
               className="relative z-30 aspect-square h-[100px] w-[100px] flex-shrink-0 overflow-hidden rounded-3xl md:h-[140px] md:w-[140px]"
               style={{
                 boxShadow: `0 0 60px rgba(${accent.colorRgb}, 0.3)`,
+                backgroundColor: `rgba(${accent.colorRgb}, 0.08)`,
               }}
             >
               {project.logoUrl.toLowerCase().endsWith(".svg") ||
               project.logoUrl.includes("#svg") ||
               project.logoUrl.includes("#logo") ? (
-                <>
-                  <div className="absolute inset-0 bg-blue-50" />
-                  <img
-                    src={project.logoUrl
-                      .replace("#svg", "")
-                      .replace("#logo", "")}
-                    alt={`${project.title} logo`}
-                    className="relative h-full w-full object-contain p-4"
-                  />
-                </>
+                <img
+                  src={project.logoUrl.replace("#svg", "").replace("#logo", "")}
+                  alt={`${project.title} logo`}
+                  className="h-full w-full object-cover"
+                />
               ) : (
                 <Image
                   src={project.logoUrl}

--- a/app/(portfolio)/projects/[slug]/page.tsx
+++ b/app/(portfolio)/projects/[slug]/page.tsx
@@ -31,7 +31,7 @@ const PROJECT_DESCRIPTIONS: Record<string, string> = {
   voicelayer:
     "Bi-directional voice I/O layer for AI assistants. VoiceBar MCP daemon with LaunchAgent auto-start. TTS via edge-tts, STT via whisper.cpp + Wispr Flow (~300ms). 2 tools (voice_speak, voice_ask) with auto-mode detection. 359 tests.",
   cmuxlayer:
-    "Terminal orchestration for AI agents. 21 MCP tools across 3 layers: surface control, agent lifecycle (spawn_agent, stop_agent, send_to_agent), and V2 facade. Playwright browser surfaces. 1,423x socket speedup via native MCP.",
+    "Terminal orchestration for AI agents. 25 MCP tools across 3 layers: surface control, agent lifecycle (spawn_agent, stop_agent, send_to_agent), and V2 facade. Playwright browser surfaces. 1,423x socket speedup via native MCP.",
   "whatsapp-mcp":
     "Hebrew-compatible WhatsApp MCP fork. Fixed Unicode search (instr() over LOWER+LIKE), dual-bridge personal+business auto-detection, self-chat safety mode. 12 MCP tools for reading and sending messages.",
   golems: `Autonomous AI agent ecosystem. ${golemsStats.packages.count} packages, ${golemsStats.agents.count} domain agents, ${golemsStats.skills.count} skills, multi-LLM routing, Night Shift autonomous coding at 4am.`,

--- a/app/(portfolio)/projects/[slug]/project-showcase-config.ts
+++ b/app/(portfolio)/projects/[slug]/project-showcase-config.ts
@@ -48,9 +48,9 @@ const configs: Record<string, ProjectShowcaseConfig> = {
     tagline: "pip install brainlayer",
     isMiniSite: true,
     stats: [
-      { value: 284, suffix: "K+", label: "Indexed chunks" },
+      { value: 335, suffix: "K+", label: "Indexed chunks" },
       { value: 12, label: "MCP tools" },
-      { value: 1415, label: "Tests passing" },
+      { value: 1848, label: "Tests passing" },
       { value: 119, label: "KG entities" },
     ],
     features: [
@@ -70,13 +70,13 @@ const configs: Record<string, ProjectShowcaseConfig> = {
         iconName: "Database",
         title: "12 MCP Tools",
         description:
-          "3 core (search, store, recall) + 9 knowledge graph (digest, entity, update, expand, tags, subscribe, unsubscribe, stats, crossref). Consolidated from 14. Old names still work via aliases.",
+          "3 core memory tools (search, store, recall) plus 9 graph, enrichment, and lifecycle tools (digest, entity, tags, expand, update, get_person, enrich, supersede, archive). Consolidated from 14. Old names still work via aliases.",
       },
       {
         iconName: "Brain",
         title: "3-Mode Enrichment",
         description:
-          "Unified brain_digest with 3 modes: full content ingestion, faceted tag generation via Gemini 2.5 Flash, and tiered selectivity (T0-T3 classifier). 284K+ chunks enriched with structured metadata.",
+          "Unified brain_digest with 3 modes: full content ingestion, faceted tag generation via Gemini 2.5 Flash, and tiered selectivity (T0-T3 classifier). 335K+ chunks enriched with structured metadata.",
       },
     ],
     installTabs: [
@@ -166,23 +166,23 @@ const configs: Record<string, ProjectShowcaseConfig> = {
     tagline: "@golems/cmux-mcp",
     isMiniSite: true,
     stats: [
-      { value: 21, label: "MCP tools" },
+      { value: 25, label: "MCP tools" },
       { value: 5, label: "Supported CLIs" },
-      { value: 278, label: "Test assertions" },
+      { value: 335, label: "Test assertions" },
       { value: 3, label: "API layers" },
     ],
     features: [
       {
         iconName: "Terminal",
-        title: "21 MCP Tools, 3 Layers",
+        title: "25 MCP Tools, 3 Layers",
         description:
-          "11 core surface tools (split, read, send, send_key, notify, rename), 8 agent lifecycle tools (spawn_agent, stop_agent, send_to_agent, wait_for), and 2 V2 facade tools (interact + kill).",
+          "13 core surface tools (split, read, send, send_key, notify, rename, move, reorder, new_surface), 10 agent lifecycle tools (spawn_agent, stop_agent, send_to_agent, wait_for, wait_for_all, my_agents), and 2 V2 facade tools (interact + kill).",
       },
       {
         iconName: "Bot",
         title: "Terminal Orchestration for AI",
         description:
-          "Spawn Claude, Codex, Cursor, Gemini, or Kiro agents into terminal panes. Each gets a tracked state machine: spawning → booting → ready → working → done. Native MCP with 1,423x socket speedup.",
+          "Spawn Claude, Codex, Cursor, Gemini, or Kiro agents into terminal panes. Each gets a tracked state machine with thinking-state detection. Chunked input delivery for resilient prompt injection. Native MCP with 1,423x socket speedup.",
       },
       {
         iconName: "Globe",
@@ -215,7 +215,7 @@ const configs: Record<string, ProjectShowcaseConfig> = {
         title: "CLI Command",
         subtitle: "spawn / interact / kill",
       },
-      { icon: "Wrench", title: "MCP Server", subtitle: "21 typed tools" },
+      { icon: "Wrench", title: "MCP Server", subtitle: "25 typed tools" },
       { icon: "Monitor", title: "cmux Socket", subtitle: "Terminal control" },
       {
         icon: "Bot",
@@ -302,7 +302,7 @@ const configs: Record<string, ProjectShowcaseConfig> = {
       { value: 11, label: "Packages" },
       { value: 55, label: "Skills" },
       { value: 5, label: "Supported CLIs" },
-      { value: 321, suffix: "+", label: "PRs merged" },
+      { value: 383, suffix: "+", label: "PRs merged" },
     ],
     features: [
       {

--- a/app/components/GolemsEcosystem.tsx
+++ b/app/components/GolemsEcosystem.tsx
@@ -123,7 +123,7 @@ export default function GolemsEcosystem() {
             Golems Ecosystem
           </h2>
           <p className="mt-2 font-[Nutmeg] text-[15px] leading-[1.3] font-light text-white/60 sm:text-[17px] md:text-[18px]">
-            3 open-source MCP servers. 44 tools. Persistent memory, voice I/O,
+            3 open-source MCP servers. 48 tools. Persistent memory, voice I/O,
             and multi-agent orchestration for AI coding assistants.
           </p>
         </div>

--- a/app/components/ProjectCard.tsx
+++ b/app/components/ProjectCard.tsx
@@ -24,6 +24,7 @@ type AccentStyles = {
   statChip: string;
   statValue: string;
   fallbackGradient: string;
+  colorRgb: string;
 };
 
 const TOOL_COUNT_REGEX = /(\d[\d,]*)\+?\s*(?:mcp\s+)?tools?\b/i;
@@ -39,6 +40,7 @@ const ACCENT_STYLES: Record<AccentName, AccentStyles> = {
     statChip: "border-blue-200/50 bg-blue-200/10",
     statValue: "text-blue-100",
     fallbackGradient: "from-blue-500 to-blue-700",
+    colorRgb: "136, 207, 248",
   },
   violet: {
     border: "border-indigo-300/20",
@@ -49,6 +51,7 @@ const ACCENT_STYLES: Record<AccentName, AccentStyles> = {
     statChip: "border-indigo-300/35 bg-indigo-400/10",
     statValue: "text-indigo-100",
     fallbackGradient: "from-indigo-800 to-[#00003F]",
+    colorRgb: "99, 102, 241",
   },
   emerald: {
     border: "border-sky-300/20",
@@ -59,6 +62,7 @@ const ACCENT_STYLES: Record<AccentName, AccentStyles> = {
     statChip: "border-sky-300/35 bg-sky-400/10",
     statValue: "text-sky-100",
     fallbackGradient: "from-cyan-800 to-[#00003F]",
+    colorRgb: "56, 189, 248",
   },
   amber: {
     border: "border-slate-300/20",
@@ -69,6 +73,7 @@ const ACCENT_STYLES: Record<AccentName, AccentStyles> = {
     statChip: "border-slate-300/35 bg-slate-400/10",
     statValue: "text-slate-100",
     fallbackGradient: "from-slate-700 to-[#00003F]",
+    colorRgb: "148, 163, 184",
   },
 };
 
@@ -249,14 +254,21 @@ function ProjectCardBase({
         >
           {project.previewImage ? (
             <>
-              {isSvgOrLogo && <div className="absolute inset-0 bg-blue-50" />}
+              {isSvgOrLogo && (
+                <div
+                  className="absolute inset-0"
+                  style={{
+                    backgroundColor: `rgba(${accent.colorRgb ?? "15, 130, 235"}, 0.06)`,
+                  }}
+                />
+              )}
               {isSvgOrLogo ? (
                 <img
                   src={project.previewImage
                     .replace("#svg", "")
                     .replace("#logo", "")}
                   alt={project.title}
-                  className="absolute inset-0 h-full w-full object-contain object-center p-8"
+                  className="absolute inset-0 h-full w-full object-contain object-center p-8 transition-transform duration-700 group-hover/card:scale-[1.04]"
                   loading={priority ? "eager" : "lazy"}
                 />
               ) : (
@@ -284,7 +296,10 @@ function ProjectCardBase({
                       .replace("#svg", "")
                       .replace("#logo", "")}
                     alt={project.title}
-                    className="h-[40%] w-[40%] object-contain opacity-30 transition-opacity duration-500 group-hover/card:opacity-50"
+                    className="h-[55%] w-[55%] object-contain opacity-90 transition-all duration-500 group-hover/card:scale-[1.05] group-hover/card:opacity-100"
+                    style={{
+                      filter: `drop-shadow(0 0 24px rgba(${accent.colorRgb ?? "15, 130, 235"}, 0.5))`,
+                    }}
                     loading="lazy"
                   />
                 </div>

--- a/public/logos/cmuxlayer-logo.svg
+++ b/public/logos/cmuxlayer-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#09090b"/>
+  <rect x="3" y="3" width="12" height="26" rx="2" stroke="#22c55e" stroke-width="2" fill="none"/>
+  <rect x="17" y="3" width="12" height="12" rx="2" stroke="#22c55e" stroke-width="2" fill="none"/>
+  <rect x="17" y="17" width="12" height="12" rx="2" stroke="#22c55e" stroke-width="2" fill="none"/>
+</svg>


### PR DESCRIPTION
## Summary
- Fix cmuxlayer architecture page: 21→25 tools, 11→13 surface layer, 8→10 lifecycle layer
- Fix security section: "All 21 tools" → "All 25 tools" (2 locations)
- Fix page description: 21→25 MCP tools
- Add cmuxlayer-logo.svg (dark square with green terminal panes, matches landing favicon)
- Supabase `short_description` updated for brainlayer (12 tools, 335K chunks, 1848 tests), voicelayer (546 tests), cmuxlayer (25 tools, 335 tests)

## Test plan
- [x] `npm run test:run` — 10 tests passed before and after changes
- [x] Verified all "21" references replaced via grep
- [x] Logo matches cmuxlayer landing page favicon exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily copy/stat updates and small UI styling tweaks for logo/SVG rendering; no backend logic or data handling changes.
> 
> **Overview**
> Updates the portfolio mini-site content to reflect **cmuxlayer’s tool expansion** (21→25 total, 11→13 surface, 8→10 lifecycle) across the architecture page copy/diagrams, the project description, and the showcase stats/features.
> 
> Refreshes other showcase numbers (e.g., BrainLayer chunk/test counts and Golems PR/tool counts), adds `public/logos/cmuxlayer-logo.svg`, and tweaks project card/hero rendering for SVG/logo assets (accent-tinted backgrounds and more prominent hover/branding styling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8951bcc33c78a7195a8832c51735558e474ea7dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->